### PR TITLE
Issue 52

### DIFF
--- a/cpp/examples/sdmm/euclidian_norm.cc
+++ b/cpp/examples/sdmm/euclidian_norm.cc
@@ -10,10 +10,11 @@ int main(int, char const **) {
   sopt::logging::set_level(SOPT_TEST_DEBUG_LEVEL);
 
   // Some typedefs for simplicity
-  typedef sopt::Vector<sopt::t_complex> t_Vector;
-  typedef sopt::RefVector<sopt::t_complex> t_RefVector;
-  typedef sopt::ConstRefVector<sopt::t_complex> t_ConstRefVector;
-  typedef sopt::Matrix<sopt::t_complex> t_Matrix;
+  typedef sopt::t_complex t_Scalar;
+  typedef sopt::Vector<t_Scalar> t_Vector;
+  typedef sopt::RefVector<t_Scalar> t_RefVector;
+  typedef sopt::ConstRefVector<t_Scalar> t_ConstRefVector;
+  typedef sopt::Matrix<t_Scalar> t_Matrix;
 
   // Creates the transformation matrices
   auto const N = 10;
@@ -40,9 +41,8 @@ int main(int, char const **) {
   // been achieved.
   // It takes the convex minimizer and the current candidate output vector as arguments.
   // The example below assumes convergence when the candidate vector does not change anymore.
-  typedef sopt::algorithm::SDMM<t_Vector::Scalar> SDMM;
   std::shared_ptr<t_Vector> previous;
-  auto relative = [&previous](SDMM const&, t_Vector const &candidate) {
+  auto relative = [&previous](t_ConstRefVector const &candidate) {
     if(not previous) {
       previous = std::make_shared<t_Vector>(candidate);
       return false;
@@ -56,7 +56,7 @@ int main(int, char const **) {
 
   // Now we can create the sdmm convex minimizer
   // Its parameters are set by calling member functions with appropriate names.
-  auto sdmm = SDMM()
+  auto sdmm = sopt::algorithm::SDMM<t_Scalar>()
     .itermax(500) // maximum number of iterations
     .gamma(1)
     .conjugate_gradient(std::numeric_limits<sopt::t_uint>::max(), 1e-12)

--- a/cpp/examples/sdmm/image.cc
+++ b/cpp/examples/sdmm/image.cc
@@ -81,8 +81,7 @@ int main(int argc, char const **argv) {
 
   SOPT_TRACE("Initializing convergence function");
   auto relvar = sopt::RelativeVariation<Scalar>(1e-2);
-  auto convergence = [&y, &sampling, &psi, &relvar](
-      sopt::algorithm::SDMM<Scalar> const&, t_Vector const &x) {
+  auto convergence = [&y, &sampling, &psi, &relvar](sopt::ConstRefVector<Scalar> const &x) -> bool {
     SOPT_INFO("||x - y||_2: {}", (y - sampling * x).stableNorm());
     SOPT_INFO("||Psi^Tx||_1: {}", sopt::l1_norm(psi.adjoint() * x));
     SOPT_INFO("||abs(x) - x||_2: {}", (x.array().abs().matrix() - x).stableNorm());

--- a/cpp/regressions/sdmm_inpainting.cc
+++ b/cpp/regressions/sdmm_inpainting.cc
@@ -65,8 +65,7 @@ sopt::algorithm::SDMM<Scalar> create_sdmm(
   auto const psi = linear_transform<Scalar>(wavelet, image.rows(), image.cols());
 
   auto relvar = RelativeVariation<Scalar>(1e-2);
-  auto convergence = [&y, &sampling, &psi, &relvar](
-      algorithm::SDMM<Scalar> const&, t_Vector const &x) {
+  auto convergence = [&y, &sampling, &psi, &relvar](sopt::ConstRefVector<Scalar> const &x) {
     INFO("||x - y||_2: " << (y - sampling * x).stableNorm());
     INFO("||Psi^Tx||_1: " << l1_norm(psi.adjoint() * x));
     INFO("||abs(x) - x||_2: " << (x.array().abs().matrix() - x).stableNorm());

--- a/cpp/sopt/relative_variation.h
+++ b/cpp/sopt/relative_variation.h
@@ -43,7 +43,7 @@ namespace sopt {
     protected:
       typename real_type<Scalar>::type epsilon_;
       bool is_first;
-      Eigen::Array<Scalar, Eigen::Dynamic, 1> previous;
+      Array<Scalar> previous;
   };
 } /* sopt  */
 

--- a/cpp/sopt/sdmm.h
+++ b/cpp/sopt/sdmm.h
@@ -43,11 +43,11 @@ template<class SCALAR> class SDMM {
     //! Type of the proximal functions
     typedef ProximalFunction<SCALAR> t_Proximal;
     //! Type of the convergence function
-    typedef std::function<bool(SDMM const&, t_Vector const&)> t_IsConverged;
+    typedef ConvergenceFunction<SCALAR> t_IsConverged;
 
     SDMM() : itermax_(std::numeric_limits<t_uint>::max()), gamma_(1e-8),
       conjugate_gradient_(std::numeric_limits<t_uint>::max(), 1e-6),
-      is_converged_([](SDMM const&, t_Vector const&) { return false; }) {}
+      is_converged_([](t_ConstRefVector const&) { return false; }) {}
     virtual ~SDMM() {}
 
     // Macro helps define properties that can be initialized as in
@@ -111,12 +111,6 @@ template<class SCALAR> class SDMM {
         return append(proximal, linear_transform<t_Vector>(l, dsizes, ladjoint, isizes));
       }
 
-    //! Sets convergence fnctions that ignore this object
-    SDMM<SCALAR>& is_converged(std::function<bool(t_Vector const&x)> const& conv) {
-      is_converged_ = [conv](SDMM<Scalar> const &, t_Vector const &x) { return conv(x); };
-      return *this;
-    }
-
     //! \brief Implements SDMM
     //! \details Follows Combettes and Pesquet "Proximal Splitting Methods in Signal Processing",
     //! arXiv:0912.3522v4 [math.OC] (2010), equation 65.
@@ -157,7 +151,7 @@ template<class SCALAR> class SDMM {
       }
 
     //! Forwards to convergence function parameter
-    bool is_converged(t_Vector const &x) const { return is_converged()(*this, x); }
+    bool is_converged(t_Vector const &x) const { return is_converged()(x); }
 
   protected:
     //! Linear transforms associated with each objective function

--- a/cpp/sopt/types.h
+++ b/cpp/sopt/types.h
@@ -55,6 +55,9 @@ namespace sopt {
     using ProximalFunction = std::function<
       void(RefVector<SCALAR>, typename real_type<SCALAR>::type, ConstRefVector<SCALAR> const&)
     >;
+  //! Typical function signature for convergence
+  template<class SCALAR = t_real>
+    using ConvergenceFunction = std::function<bool(ConstRefVector<SCALAR> const&)>;
 }
 #endif
 

--- a/cpp/tests/sdmm.cc
+++ b/cpp/tests/sdmm.cc
@@ -62,7 +62,6 @@ TEST_CASE("Introspect SDMM with L_i = Identity and Euclidian objectives", "[sdmm
   t_Vector const target0 = t_Vector::Zero(N);
   t_Vector const target1 = t_Vector::Random(N);
 
-  auto always_false = [](algorithm::SDMM<Scalar> const&, t_Vector const &) { return false; };
   auto const g0 = proximal::translate(proximal::EuclidianNorm(), -target0);
   auto const g1 = proximal::translate(proximal::EuclidianNorm(), -target1);
   t_Vector const input = 10 * t_Vector::Random(N);
@@ -71,7 +70,6 @@ TEST_CASE("Introspect SDMM with L_i = Identity and Euclidian objectives", "[sdmm
   sdmm.itermax(10)
     .gamma(0.01)
     .conjugate_gradient(std::numeric_limits<t_uint>::max(), 1e-12)
-    .is_converged(always_false) // iterates until itermax is reached
     .append(g0, Id)
     .append(g1, Id);
 


### PR DESCRIPTION
Closes #52.

Moved to using Eigen::RefEigen::Matrix rather than Eigen::Matrix. It should make it easier to call C functions without copying data, and vice versa.
