### PR TITLE
Changes PADMM input to take initial guess

### DIFF
--- a/cpp/examples/proximal_admm/euclidian_norm.cc
+++ b/cpp/examples/proximal_admm/euclidian_norm.cc
@@ -27,7 +27,7 @@ int main(int, char const **) {
   auto prox_g0 = sopt::proximal::translate(sopt::proximal::EuclidianNorm(), -target0);
   auto prox_g1 = sopt::proximal::translate(sopt::proximal::EuclidianNorm(), -target1);
 
-  auto padmm = sopt::algorithm::ProximalADMM<t_Scalar>(prox_g0, prox_g1)
+  auto padmm = sopt::algorithm::ProximalADMM<t_Scalar>(prox_g0, prox_g1, t_Vector::Zero(N))
                    .itermax(5000)
                    .is_converged(sopt::RelativeVariation<t_Scalar>(1e-12))
                    .gamma(0.01)

--- a/cpp/examples/proximal_admm/inpainting.cc
+++ b/cpp/examples/proximal_admm/inpainting.cc
@@ -81,7 +81,7 @@ int main(int argc, char const **argv) {
   }
 
   SOPT_TRACE("Creating proximal-ADMM Functor");
-  auto const padmm = sopt::algorithm::L1ProximalADMM<Scalar>()
+  auto const padmm = sopt::algorithm::L1ProximalADMM<Scalar>(y)
                          .itermax(500)
                          .gamma(1e-1)
                          .relative_variation(5e-4)
@@ -99,7 +99,7 @@ int main(int argc, char const **argv) {
                          .Phi(sampling);
 
   SOPT_TRACE("Starting proximal-ADMM");
-  auto const diagnostic = padmm(Vector::Map(y.data(), y.size()));
+  auto const diagnostic = padmm(Vector::Zero(image.size()));
   SOPT_TRACE("proximal-ADMM returned {}", diagnostic.good);
 
   // diagnostic should tell us the function converged

--- a/cpp/regressions/padmm_inpainting.cc
+++ b/cpp/regressions/padmm_inpainting.cc
@@ -21,10 +21,11 @@ typedef sopt::Matrix<Scalar> t_Matrix;
 
 sopt::algorithm::L1ProximalADMM<Scalar> create_admm(sopt::LinearTransform<t_Vector> const &phi,
                                                     sopt::LinearTransform<t_Vector> const &psi,
-                                                    sopt_l1_param_padmm const &params) {
+                                                    sopt_l1_param_padmm const &params,
+                                                    t_Vector const &target) {
 
   using namespace sopt;
-  return algorithm::L1ProximalADMM<Scalar>()
+  return algorithm::L1ProximalADMM<Scalar>(target)
       .itermax(params.max_iter + 1)
       .gamma(params.gamma)
       .relative_variation(params.rel_obj)
@@ -88,9 +89,9 @@ TEST_CASE("Compare ADMM C++ and C", "") {
     SECTION(fmt::format("With {} iterations", i)) {
       sopt_l1_param_padmm c_params = params;
       c_params.max_iter = i;
-      auto admm = ::create_admm(sampling, psi, c_params);
+      auto admm = ::create_admm(sampling, psi, c_params, y);
       t_Vector cpp(image.size());
-      admm(cpp, y);
+      admm(cpp, t_Vector::Zero(image.size()));
 
       t_Vector c = t_Vector::Zero(image.size());
       t_Vector l1_weights = t_Vector::Ones(image.size());

--- a/cpp/tests/padmm.cc
+++ b/cpp/tests/padmm.cc
@@ -27,12 +27,12 @@ TEST_CASE("Proximal ADMM with ||x - x0||_2 functions", "[padmm][integration]") {
   auto const g0 = proximal::translate(proximal::EuclidianNorm(), -target0);
   auto const g1 = proximal::translate(proximal::EuclidianNorm(), -target1);
 
-  t_Vector const input = t_Vector::Zero(N);
   t_Matrix const mId = -t_Matrix::Identity(N, N);
 
   t_Vector const translation = t_Vector::Ones(N) * 5;
-  auto const padmm = algorithm::ProximalADMM<Scalar>(g0, g1).Phi(mId).itermax(3000).gamma(0.01);
-  auto const result = padmm(input);
+  auto const padmm = algorithm::ProximalADMM<Scalar>(g0, g1, t_Vector::Zero(N))
+    .Phi(mId).itermax(3000).gamma(0.01);
+  auto const result = padmm(t_Vector::Zero(N));
 
   t_Vector const segment = (target1 - target0).normalized();
   t_real const alpha = (result.x - target0).transpose() * segment;
@@ -51,7 +51,7 @@ TEST_CASE("Check type returned on setting variables") {
   // Yeah, could be static asserts
   using namespace sopt;
   using namespace sopt::algorithm;
-  L1ProximalADMM<double> admm;
+  L1ProximalADMM<double> admm(Vector<double>::Zero(0));
   CHECK(is_l1_proximal_ref<decltype(admm.itermax(500))>::value);
   CHECK(is_l1_proximal_ref<decltype(admm.gamma(1e-1))>::value);
   CHECK(is_l1_proximal_ref<decltype(admm.relative_variation(5e-4))>::value);
@@ -65,6 +65,7 @@ TEST_CASE("Check type returned on setting variables") {
   CHECK(is_l1_proximal_ref<decltype(admm.residual_convergence(1.001))>::value);
   CHECK(is_l1_proximal_ref<decltype(admm.lagrange_update_scale(0.9))>::value);
   CHECK(is_l1_proximal_ref<decltype(admm.nu(1e0))>::value);
+  CHECK(is_l1_proximal_ref<decltype(admm.target(Vector<double>::Zero(0)))>::value);
   typedef ConvergenceFunction<double> ConvFunc;
   CHECK(is_l1_proximal_ref<decltype(admm.is_converged(std::declval<ConvFunc>()))>::value);
   CHECK(is_l1_proximal_ref<decltype(admm.is_converged(std::declval<ConvFunc &>()))>::value);


### PR DESCRIPTION
The main changes:
- the target vector y is not a mandatory setting, required in the constructor
- the PADMM functors take an initial guess for the image
- this initial guess is currently ignored... much as it is in the C code
