### PR TITLE
SARA is captured as a reference in the linear transform lambda,

### DIFF
--- a/cpp/sopt/wavelets.h
+++ b/cpp/sopt/wavelets.h
@@ -15,8 +15,8 @@ namespace {
 //! Thin linear-transform wrapper around some operator accepting direct and indirect
 template <class T, class OP> LinearTransform<Vector<T>> linear_transform(OP const &op) {
   return LinearTransform<Vector<T>>(
-      [&op](Vector<T> &out, Vector<T> const &x) { op.indirect(x.array(), out.array()); },
-      [&op](Vector<T> &out, Vector<T> const &x) { op.direct(out.array(), x.array()); });
+      [op](Vector<T> &out, Vector<T> const &x) { op.indirect(x.array(), out.array()); },
+      [op](Vector<T> &out, Vector<T> const &x) { op.direct(out.array(), x.array()); });
 }
 //! \brief Thin linear-transform wrapper around 2d wavelets
 //! \details Goes back and forth between vector representations and image representations, where
@@ -31,7 +31,7 @@ linear_transform(OP const &op, t_uint rows, t_uint cols, t_uint factor = 1) {
   if(rows == 1 or cols == 1)
     return linear_transform<T, OP>(op);
   return LinearTransform<Vector<T>>(
-      [&op, rows, cols, factor](Vector<T> &out, Vector<T> const &x) {
+      [op, rows, cols, factor](Vector<T> &out, Vector<T> const &x) {
         assert(static_cast<t_uint>(x.size()) == rows * cols * factor);
         out.resize(rows * cols);
         auto signal = Image<T>::Map(out.data(), rows, cols);
@@ -39,7 +39,7 @@ linear_transform(OP const &op, t_uint rows, t_uint cols, t_uint factor = 1) {
         op.indirect(coeffs, signal);
       },
       {{0, 1, static_cast<t_int>(rows * cols)}},
-      [&op, rows, cols, factor](Vector<T> &out, Vector<T> const &x) {
+      [op, rows, cols, factor](Vector<T> &out, Vector<T> const &x) {
         assert(static_cast<t_uint>(x.size()) == rows * cols);
         out.resize(rows * cols * factor);
         auto const signal = Image<T>::Map(x.data(), rows, cols);
@@ -208,7 +208,7 @@ LinearTransform<Vector<T>> linear_transform(wavelets::SARA const &sara, t_uint r
   auto const factor = sara.size();
   auto const normalization = std::sqrt(sara.size()) / std::sqrt(comm.all_sum_all(sara.size()));
   return LinearTransform<Vector<T>>(
-      [&sara, rows, cols, factor, comm, normalization](Vector<T> &out, Vector<T> const &x) {
+      [sara, rows, cols, factor, comm, normalization](Vector<T> &out, Vector<T> const &x) {
         assert(static_cast<t_uint>(x.size()) == rows * cols * factor);
         out.resize(rows * cols);
         if(sara.size() == 0)
@@ -222,7 +222,7 @@ LinearTransform<Vector<T>> linear_transform(wavelets::SARA const &sara, t_uint r
         comm.all_sum_all(out);
       },
       {{0, 1, static_cast<t_int>(rows * cols)}},
-      [&sara, rows, cols, factor, normalization](Vector<T> &out, Vector<T> const &x) {
+      [sara, rows, cols, factor, normalization](Vector<T> &out, Vector<T> const &x) {
         assert(static_cast<t_uint>(x.size()) == rows * cols);
         out.resize(rows * cols * factor);
         auto const signal = Image<T>::Map(x.data(), rows, cols);


### PR DESCRIPTION
 but goes out of scope in some cases. It now is a copy capture.

This means the SARA LinearTransform operator can now be made a shared pointer.