### PR TITLE
Fix path typo on deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -214,7 +214,7 @@ deploy:
   skip-cleanup: true
   github-token: $GITHUB_TOKEN  # Set in the settings page of your repository, as a secure variable
   keep-history: true
-  local-dir: cpp/docs/html
+  local-dir: build/cpp/docs/html
   target-branch: website # FIXME: Default gh-pages, set this for now to have both.
   verbose: true # FIXME: just at first to see logs
   on:


### PR DESCRIPTION
As it goes from the top of the repository, not from where the script is at the
moment.