### PR TITLE
MPI guard

### DIFF
--- a/cpp/sopt/wavelets.h
+++ b/cpp/sopt/wavelets.h
@@ -5,7 +5,9 @@
 // Convenience header to include wavelets headers and additional utilities
 #include "sopt/config.h"
 #include "sopt/linear_transform.h"
+#ifdef SOPT_MPI
 #include "sopt/mpi/communicator.h"
+#endif
 #include "sopt/wavelets/sara.h"
 #include "sopt/wavelets/wavelets.h"
 


### PR DESCRIPTION
Discovered via Purify attempting to use MPI when set as OFF.
Who knows why it's working on Travis when SOPT is compiled with MPI OFF??