### PR TITLE
SARA 1d wavelet fix

### DIFF
--- a/cpp/sopt/wavelets.h
+++ b/cpp/sopt/wavelets.h
@@ -31,7 +31,6 @@ LinearTransform<Vector<T>> linear_transform(OP const &op) {
 template <class T, class OP>
 LinearTransform<Vector<T>> linear_transform(OP const &op, t_uint rows, t_uint cols,
                                             t_uint factor = 1) {
-  if (rows == 1 or cols == 1) return linear_transform<T, OP>(op);
   return LinearTransform<Vector<T>>(
       [op, rows, cols, factor](Vector<T> &out, Vector<T> const &x) {
         assert(static_cast<t_uint>(x.size()) == rows * cols * factor);

--- a/cpp/sopt/wavelets/sara.h
+++ b/cpp/sopt/wavelets/sara.h
@@ -167,7 +167,7 @@ void SARA::indirect(Eigen::ArrayBase<T1> const &coeffs, Eigen::ArrayBase<T0> &si
 #ifndef SOPT_OPENMP
     SOPT_TRACE("Calling indirect sara without threads");
 #endif
-
+    signal = T0::Zero(signal.rows(), signal.cols());
     if (Ncols == 1)
       for (size_type i = 0; i < size(); ++i) signal.col(0) += at(i).indirect(coeffs.col(i));
     else

--- a/cpp/tests/sara.cc
+++ b/cpp/tests/sara.cc
@@ -58,34 +58,66 @@ TEST_CASE("Linear-transform wrapper", "[wavelet]") {
   using namespace sopt;
   SARA const sara{std::make_tuple(std::string{"DB3"}, 1u), std::make_tuple(std::string{"DB1"}, 2u),
                   std::make_tuple(std::string{"DB1"}, 3u)};
-
-  auto const rows = 256, cols = 256;
-  auto const Psi = linear_transform<t_real>(sara, rows, cols);
-  SECTION("Indirect transform") {
-    Image<> const image = Image<>::Random(rows, cols);
-    Image<> const expected = sara.direct(image);
-    // The linear transform expects a column vector as input
-    auto const as_vector = Vector<>::Map(image.data(), image.size());
-    // And it returns a column vector as well
-    Vector<> const actual = Psi.adjoint() * as_vector;
-    CHECK(actual.size() == expected.size());
-    auto const coeffs = Image<>::Map(actual.data(), image.rows(), image.cols() * sara.size());
-    CHECK(expected.rows() == coeffs.rows());
-    CHECK(expected.cols() == coeffs.cols());
-    CHECK(coeffs.isApprox(expected, 1e-8));
+  SECTION("1d") {
+    auto const rows = 256, cols = 1;
+    auto const Psi = linear_transform<t_real>(sara, rows, cols);
+    SECTION("Indirect transform") {
+      Image<> const image = Image<>::Random(rows, cols);
+      Image<> const expected = sara.direct(image);
+      // The linear transform expects a column vector as input
+      auto const as_vector = Vector<>::Map(image.data(), image.size());
+      // And it returns a column vector as well
+      Vector<> const actual = Psi.adjoint() * as_vector;
+      CHECK(actual.size() == expected.size());
+      auto const coeffs = Image<>::Map(actual.data(), image.rows(), image.cols() * sara.size());
+      CHECK(expected.rows() == coeffs.rows());
+      CHECK(expected.cols() == coeffs.cols());
+      CHECK(coeffs.isApprox(expected, 1e-8));
+    }
+    SECTION("direct transform") {
+      Image<> const coeffs = Image<>::Random(rows, cols * sara.size());
+      Image<> const expected = sara.indirect(coeffs);
+      // The linear transform expects a column vector as input
+      auto const as_vector = Vector<>::Map(coeffs.data(), coeffs.size());
+      // And it returns a column vector as well
+      Vector<> const actual = Psi * as_vector;
+      CHECK(actual.size() == expected.size());
+      CHECK(coeffs.cols() % sara.size() == 0);
+      auto const image = Image<>::Map(actual.data(), coeffs.rows(), coeffs.cols() / sara.size());
+      CHECK(expected.rows() == image.rows());
+      CHECK(expected.cols() == image.cols());
+      CHECK(image.isApprox(expected, 1e-8));
+    }
   }
-  SECTION("direct transform") {
-    Image<> const coeffs = Image<>::Random(rows, cols * sara.size());
-    Image<> const expected = sara.indirect(coeffs);
-    // The linear transform expects a column vector as input
-    auto const as_vector = Vector<>::Map(coeffs.data(), coeffs.size());
-    // And it returns a column vector as well
-    Vector<> const actual = Psi * as_vector;
-    CHECK(actual.size() == expected.size());
-    CHECK(coeffs.cols() % sara.size() == 0);
-    auto const image = Image<>::Map(actual.data(), coeffs.rows(), coeffs.cols() / sara.size());
-    CHECK(expected.rows() == image.rows());
-    CHECK(expected.cols() == image.cols());
-    CHECK(image.isApprox(expected, 1e-8));
+  SECTION("2d") {
+    auto const rows = 256, cols = 256;
+    auto const Psi = linear_transform<t_real>(sara, rows, cols);
+    SECTION("Indirect transform") {
+      Image<> const image = Image<>::Random(rows, cols);
+      Image<> const expected = sara.direct(image);
+      // The linear transform expects a column vector as input
+      auto const as_vector = Vector<>::Map(image.data(), image.size());
+      // And it returns a column vector as well
+      Vector<> const actual = Psi.adjoint() * as_vector;
+      CHECK(actual.size() == expected.size());
+      auto const coeffs = Image<>::Map(actual.data(), image.rows(), image.cols() * sara.size());
+      CHECK(expected.rows() == coeffs.rows());
+      CHECK(expected.cols() == coeffs.cols());
+      CHECK(coeffs.isApprox(expected, 1e-8));
+    }
+    SECTION("direct transform") {
+      Image<> const coeffs = Image<>::Random(rows, cols * sara.size());
+      Image<> const expected = sara.indirect(coeffs);
+      // The linear transform expects a column vector as input
+      auto const as_vector = Vector<>::Map(coeffs.data(), coeffs.size());
+      // And it returns a column vector as well
+      Vector<> const actual = Psi * as_vector;
+      CHECK(actual.size() == expected.size());
+      CHECK(coeffs.cols() % sara.size() == 0);
+      auto const image = Image<>::Map(actual.data(), coeffs.rows(), coeffs.cols() / sara.size());
+      CHECK(expected.rows() == image.rows());
+      CHECK(expected.cols() == image.cols());
+      CHECK(image.isApprox(expected, 1e-8));
+    }
   }
 }


### PR DESCRIPTION
The incorrect function was being called when the number of columns in the SARA wavelet transform was one, the 2d transform was being called instead of the 1d transform. This PR should fix that, and allow the use of 1d wavelets with SARA.

I also added a unit test for the 1d SARA transform.