### PR TITLE
Updated power method and added ability to normalise operator.

### DIFF
--- a/cpp/sopt/power_method.h
+++ b/cpp/sopt/power_method.h
@@ -41,13 +41,12 @@ std::tuple<t_real, T> power_method(const sopt::LinearTransform<T> &op, const t_u
     estimate_eigen_vector = estimate_eigen_vector / estimate_eigen_value;
     SOPT_DEBUG(" -[PM] Iteration: {}, norm = {}", i + 1, estimate_eigen_value);
     converged = scalvar(std::sqrt(estimate_eigen_value));
+    old_value = estimate_eigen_value;
     if (converged) {
-      old_value = estimate_eigen_value;
       SOPT_DEBUG("Converged to norm = {}, relative difference < {}", std::sqrt(old_value),
                  relative_difference);
       break;
     }
-    old_value = estimate_eigen_value;
   }
   return std::make_tuple(std::sqrt(old_value), estimate_eigen_vector);
 }

--- a/cpp/sopt/power_method.h
+++ b/cpp/sopt/power_method.h
@@ -56,12 +56,12 @@ std::tuple<t_real, T, std::shared_ptr<sopt::LinearTransform<T>>> normalise_opera
     const t_real &relative_difference, const T &initial_vector) {
   const auto result = power_method<T>(*op, niters, relative_difference, initial_vector);
   const t_real norm = std::get<0>(result);
-  const sopt::LinearTransform<T> normed_op = {
-      [op, norm](T &output, const T &input) { output = (*op * input) / norm; },
-      [op, norm](T &output, const T &input) { output = (op->adjoint() * input) / norm; }};
-
-  return std::make_tuple(std::get<0>(result), std::get<1>(result),
-                         std::make_shared<sopt::LinearTransform<T>>(std::move(normed_op)));
+  return std::make_tuple(
+      std::get<0>(result), std::get<1>(result),
+      std::make_shared<sopt::LinearTransform<T>>(
+          [op, norm](T &output, const T &input) { output = (*op * input) / norm; }, op->sizes(),
+          [op, norm](T &output, const T &input) { output = (op->adjoint() * input) / norm; },
+          op->adjoint().sizes()));
 }
 template <class T>
 std::tuple<t_real, T, sopt::LinearTransform<T>> normalise_operator(

--- a/cpp/tests/power_method.cc
+++ b/cpp/tests/power_method.cc
@@ -48,8 +48,8 @@ TEST_CASE("Power Method (from Purify)") {
   using namespace sopt;
   typedef t_real Scalar;
   auto const N = 10;
-  const t_uint power_iters = 1000;
-  const t_real power_tol = 1e-4;
+  const t_uint power_iters = 100000;
+  const t_real power_tol = 1e-6;
   Eigen::EigenSolver<Matrix<Scalar>> es;
   Matrix<Scalar> A(N, N);
   std::iota(A.data(), A.data() + A.size(), 0);
@@ -85,7 +85,7 @@ TEST_CASE("Power Method (from Purify)") {
     CAPTURE(op_norm * op_norm);
     CAPTURE(op_eigen_vector);
     CAPTURE(eigenvector);
-    CHECK(std::abs(op_norm * op_norm - eigenvalue) < power_tol * power_tol);
+    CHECK(op_norm == Approx(std::sqrt(std::abs(eigenvalue))).epsilon(power_tol));
     CHECK(op_eigen_vector.isApprox(eigenvector, power_tol));
     auto const norm_operator_result =
         algorithm::normalise_operator<Vector<t_complex>>(op, power_iters, power_tol, input);

--- a/cpp/tests/power_method.cc
+++ b/cpp/tests/power_method.cc
@@ -71,13 +71,14 @@ TEST_CASE("Power Method (from Purify)") {
 
   SECTION("Power Method") {
     const sopt::LinearTransform<Vector<t_complex>> op = {forward, backward};
-    auto const result = algorithm::power_method<Vector<t_complex>>(op, power_iters,
-                                                                   power_tol, input);
+    auto const result =
+        algorithm::power_method<Vector<t_complex>>(op, power_iters, power_tol, input);
     const t_real op_norm = std::get<0>(result);
     const Vector<t_complex> op_eigen_vector_c = std::get<1>(result);
     CHECK(op_eigen_vector_c.unaryExpr([](t_complex x) { return std::arg(x); })
               .isApprox(Vector<t_complex>::Constant(op_eigen_vector_c.size(),
-                                                    std::arg(op_eigen_vector_c(0)))));
+                                                    std::arg(op_eigen_vector_c(0))),
+                        power_tol));
     const Vector<t_complex> op_eigen_vector =
         op_eigen_vector_c * std::polar<t_real>(1, -std::arg(op_eigen_vector_c(0)));
     CAPTURE(eigenvalue);
@@ -86,10 +87,12 @@ TEST_CASE("Power Method (from Purify)") {
     CAPTURE(eigenvector);
     CHECK(std::abs(op_norm * op_norm - eigenvalue) < power_tol * power_tol);
     CHECK(op_eigen_vector.isApprox(eigenvector, power_tol));
-    auto const norm_operator_result = algorithm::normalise_operator<Vector<t_complex>>(op, power_iters,
-                                                                   power_tol, input);
+    auto const norm_operator_result =
+        algorithm::normalise_operator<Vector<t_complex>>(op, power_iters, power_tol, input);
     CHECK(std::get<0>(norm_operator_result) == Approx(op_norm).epsilon(1e-12));
     CHECK(std::get<1>(norm_operator_result).isApprox(op_eigen_vector_c, 1e-12));
-    CHECK(((op * input)/op_norm).eval().isApprox((std::get<2>(norm_operator_result) * input).eval(), 1e-12));
+    CHECK(((op * input) / op_norm)
+              .eval()
+              .isApprox((std::get<2>(norm_operator_result) * input).eval(), 1e-12));
   }
 }

--- a/cpp/tests/power_method.cc
+++ b/cpp/tests/power_method.cc
@@ -94,5 +94,8 @@ TEST_CASE("Power Method (from Purify)") {
     CHECK(((op * input) / op_norm)
               .eval()
               .isApprox((std::get<2>(norm_operator_result) * input).eval(), 1e-12));
+    CHECK(((op.adjoint() * input) / op_norm)
+              .eval()
+              .isApprox((std::get<2>(norm_operator_result).adjoint() * input).eval(), 1e-12));
   }
 }


### PR DESCRIPTION
To speed up the power method, it is useful to warm start from an estimate of the eigen vector. 
Additionally, it is useful to normalise the linear operator, in a way that doesn't require creating a copy or new operator.

In this PR, I provide a function that will normalise the linear operator, using the old one as a std::smart_ptr. The power method will now also return the eigen vector as well as the eigen value.

PURIFY needs to be updated before this PR is merged!