### PR TITLE
issue when doing non-negative least squares (avoid extra calculation)

### DIFF
--- a/cpp/sopt/imaging_forward_backward.h
+++ b/cpp/sopt/imaging_forward_backward.h
@@ -354,8 +354,9 @@ bool ImagingForwardBackward<SCALAR>::objective_convergence(ScalarRelativeVariati
                                                            t_Vector const &residual) const {
   if (static_cast<bool>(objective_convergence())) return objective_convergence()(x, residual);
   if (scalvar.relative_tolerance() <= 0e0) return true;
-  auto const current = sopt::l1_norm(Psi().adjoint() * x, l1_proximal_weights()) * gamma() +
-                       std::pow(sopt::l2_norm(residual), 2) / (2 * sigma() * sigma());
+  auto const current =
+      ((gamma() > 0) ? sopt::l1_norm(Psi().adjoint() * x, l1_proximal_weights()) * gamma() : 0) +
+      std::pow(sopt::l2_norm(residual), 2) / (2 * sigma() * sigma());
   return scalvar(current);
 };
 
@@ -368,7 +369,7 @@ bool ImagingForwardBackward<SCALAR>::objective_convergence(mpi::Communicator con
   if (static_cast<bool>(objective_convergence())) return objective_convergence()(x, residual);
   if (scalvar.relative_tolerance() <= 0e0) return true;
   auto const current = obj_comm.all_sum_all<t_real>(
-      sopt::l1_norm(Psi().adjoint() * x, l1_proximal_weights()) * gamma() +
+      ((gamma() > 0) ? sopt::l1_norm(Psi().adjoint() * x, l1_proximal_weights()) * gamma() : 0) +
       std::pow(sopt::l2_norm(residual), 2) / (2 * sigma() * sigma()));
   return scalvar(current);
 };


### PR DESCRIPTION
Avoid computing wavelet transform in objective function for zero regularisation parameter in forward backward. Provides a speed up!