### PR TITLE
allign changes with purify and tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -223,10 +223,10 @@ matrix:
       env:
         - TITLE="Documentation - GCC"
         - DOCS=ON
-        - BUILD_CMD='make doc VERBOSE=1'
+        - BUILD_CMD='make docweb VERBOSE=1'
       script:
         - chmod o+w . # To allow docker to create the build directory
-        - docker run --rm -v $(pwd):/mydata uclrits/sopt /bin/sh -c "mkdir build; cd build; cmake .. -Ddocs=${DOCS}; eval ${BUILD_CMD}"
+        - docker run --rm -v $(pwd):/mydata uclrits/sopt /bin/sh -c "mkdir build; cd build; cmake .. -Ddocs=${DOCS} -Dweb=ON; eval ${BUILD_CMD}"
 
     - os: linux
       addons:

--- a/cpp/docs/CMakeLists.txt
+++ b/cpp/docs/CMakeLists.txt
@@ -11,3 +11,9 @@ configure_file(
 add_custom_target(doc ALL
   COMMAND doxygen
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+if (web)
+   add_custom_target(docweb
+     COMMAND sed -i -e 's@namespacesopt@http://astro-informatics.github.io/sopt/&@g' -e 's@<filename>@&http://astro-informatics.github.io/sopt/@g' ${CMAKE_CURRENT_BINARY_DIR}/html/sopt.tag
+     DEPENDS doc)
+endif()

--- a/cpp/docs/CONTRIBUTORS.md
+++ b/cpp/docs/CONTRIBUTORS.md
@@ -5,49 +5,59 @@ Contributors {#contributors}
 have since been made by a number of others. The full list of contributors is as follows:
 
 <div class="contributors">
+
 ![](photo_mayeul.jpg)
 <div class="text">
-Dr. Mayeul D'Avezac <br> [website](https://github.com/mdavezac)
+Dr. Mayeul D'Avezac <br/>
+[website](https://github.com/mdavezac)
 </div>
 
 ![](photo_rafael.jpg)
 <div class="text">
-Dr. Rafael Carrillo <br> [website](https://www.researchgate.net/profile/Rafael_Carrillo2)
+Dr. Rafael Carrillo <br/>
+[website](https://www.researchgate.net/profile/Rafael_Carrillo2)
 </div>
 
 ![](photo_ilektra.jpg)
 <div class="text">
-Dr. Ilektra Christidi <br> [website](https://github.com/ilectra)
+Dr. Ilektra Christidi <br/>
+[website](https://github.com/ilectra)
 </div>
 
 ![](photo_roland.jpg)
 <div class="text">
-Dr. Roland Guichard <br> [website](https://github.com/UCLGuichard)
+Dr. Roland Guichard <br/>
+[website](https://github.com/UCLGuichard)
 </div>
 
 ![](photo_vijay.jpg)
 <div class="text">
-Dr. Vijay Kartik <br> [website](https://people.epfl.ch/vijay.kartik)
+Dr. Vijay Kartik <br/>
+[website](https://people.epfl.ch/vijay.kartik)
 </div>
 
 ![](photo_jason.jpg)
 <div class="text">
- Dr. Jason D. McEwen <br> [website](http://www.jasonmcewen.org)
+Dr. Jason D. McEwen <br/>
+[website](http://www.jasonmcewen.org)
 </div>
 
 ![](photo_david.jpg)
 <div class="text">
-Dr. David Perez-Suarez <br> [website](https://dpshelio.github.io)
+Dr. David Perez-Suarez <br/>
+[website](https://dpshelio.github.io)
 </div>
 
 ![](photo_luke.jpg)
 <div class="text">
- Mr. Luke Pratley <br> [website](https://www.lukepratley.com)
+Mr. Luke Pratley <br/>
+[website](https://www.lukepratley.com)
 </div>
 
 ![](photo_yves.jpg)
 <div class="text">
-Dr. Yves Wiaux <br> [website](http://basp.eps.hw.ac.uk/)
+Dr. Yves Wiaux <br/>
+[website](http://basp.eps.hw.ac.uk/)
 </div>
 
 </div>

--- a/cpp/docs/Doxyfile.in
+++ b/cpp/docs/Doxyfile.in
@@ -2133,7 +2133,7 @@ TAGFILES               =
 # tag file that is based on the input files it reads. See section "Linking to
 # external documentation" for more information about the usage of tag files.
 
-GENERATE_TAGFILE       =
+GENERATE_TAGFILE       = html/sopt.tag
 
 # If the ALLEXTERNALS tag is set to YES, all external class will be listed in
 # the class index. If set to NO, only the inherited external classes will be


### PR DESCRIPTION
tags are used in the documentation to link with external libraries. Here we create the tags for sopt so purify can use them and have inter-linked documentation.