### PR TITLE
Update version so we know which version we are developing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ include(LookUp-GreatCMakeCookOff)
 
 # Version and git hash id
 include(VersionAndGitRef)
-set_version(3.0.1)
+set_version(3.1.0)
 get_gitref()
 
 option(tests          "Enable testing"                         on)


### PR DESCRIPTION
So we don't get into the same silly problem on the next release.