### PR TITLE
added imaging_primal_dual.h to the cmake headers list

### DIFF
--- a/cpp/sopt/CMakeLists.txt
+++ b/cpp/sopt/CMakeLists.txt
@@ -1,9 +1,10 @@
 # list of headers
 set(headers
   bisection_method.h chained_operators.h credible_region.h
-  primal_dual.h imaging_padmm.h logging.disabled.h 
+  imaging_padmm.h logging.disabled.h
   forward_backward.h imaging_forward_backward.h
   joint_map.h
+  imaging_primal_dual.h primal_dual.h
   maths.h proximal.h relative_variation.h sdmm.h
   wavelets.h conjugate_gradient.h l1_proximal.h logging.enabled.h padmm.h proximal_expression.h
   reweighted.h types.h wrapper.h exception.h linear_transform.h logging.h positive_quadrant.h


### PR DESCRIPTION
Currently when sopt is installed it does not copy the imaging_primal_dual.h header. This fixes that!