### PR TITLE
Updating Eigen3 version

### DIFF
--- a/cmake_files/dependencies.cmake
+++ b/cmake_files/dependencies.cmake
@@ -1,6 +1,6 @@
 include(PackageLookup)  # check for existence, or install external projects
 
-lookup_package(Eigen3 REQUIRED DOWNLOAD_BY_DEFAULT ARGUMENTS URL "http://bitbucket.org/eigen/eigen/get/3.2.tar.gz" MD5 "7b929312ebe77ae7d441e715a1ca7635") # "035ccc791f046f48e90bb1fb42ce227e")
+lookup_package(Eigen3 REQUIRED DOWNLOAD_BY_DEFAULT ARGUMENTS URL "http://bitbucket.org/eigen/eigen/get/3.2.tar.gz" MD5 "7b929312ebe77ae7d441e715a1ca7635")
 if(logging)
   lookup_package(spdlog REQUIRED)
 endif()

--- a/cmake_files/dependencies.cmake
+++ b/cmake_files/dependencies.cmake
@@ -1,6 +1,6 @@
 include(PackageLookup)  # check for existence, or install external projects
 
-lookup_package(Eigen3 REQUIRED DOWNLOAD_BY_DEFAULT ARGUMENTS URL "http://bitbucket.org/eigen/eigen/get/3.2.tar.gz" MD5 "035ccc791f046f48e90bb1fb42ce227e")
+lookup_package(Eigen3 REQUIRED DOWNLOAD_BY_DEFAULT ARGUMENTS URL "http://bitbucket.org/eigen/eigen/get/3.2.tar.gz" MD5 "7b929312ebe77ae7d441e715a1ca7635") # "035ccc791f046f48e90bb1fb42ce227e")
 if(logging)
   lookup_package(spdlog REQUIRED)
 endif()


### PR DESCRIPTION
The version of Eigen 3 in file `cmake_files/dependencies.cmake` is outdated, so the MD5 hash need to be updated to the latest version. This PR does that 