### PR TITLE
Minor CI fixes

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -36,7 +36,7 @@ jobs:
       matrix:
           os:
             - ubuntu-20.04
-            - macos-11
+            - macos-12
           cc:
             - gcc-9
             - clang
@@ -55,8 +55,8 @@ jobs:
             - cc: clang
               cxx: g++-9
             - os: ubuntu-20.04
-              cc: clang
-              cxx: clang++
+#              cc: clang
+#              cxx: clang++
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -57,6 +57,8 @@ jobs:
             - os: ubuntu-20.04
               cc: clang
               cxx: clang++
+            - os: macos-11
+              mpi: "on"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [ development ]
     if: github.event.pull_request.draft == false
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
+        required: false
+        default: false
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
@@ -54,6 +60,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+
+   # Enable tmate debugging of manually-triggered workflows if the input option was provided
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+      if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
 
     - name: Install Dependencies on Ubunutu
       if: ${{ contains(matrix.os, 'ubuntu') }}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -69,6 +69,7 @@ jobs:
     - name: Install Dependencies on Ubunutu
       if: ${{ contains(matrix.os, 'ubuntu') }}
       run: |
+        sudo apt update
         sudo apt install libtiff5-dev openmpi-bin libopenmpi-dev libeigen3-dev libyaml-cpp-dev ccache
         pip install conan
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -36,7 +36,7 @@ jobs:
       matrix:
           os:
             - ubuntu-20.04
-            - macos-12
+            - macos-11
           cc:
             - gcc-9
             - clang
@@ -55,8 +55,8 @@ jobs:
             - cc: clang
               cxx: g++-9
             - os: ubuntu-20.04
-#              cc: clang
-#              cxx: clang++
+              cc: clang
+              cxx: clang++
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -21,6 +21,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          sudo apt update
           sudo apt install libtiff5-dev openmpi-bin libopenmpi-dev libeigen3-dev libyaml-cpp-dev doxygen graphviz
           pip install conan
 

--- a/.github/workflows/macdebug.yml
+++ b/.github/workflows/macdebug.yml
@@ -1,11 +1,6 @@
-name: CMake
+name: MacOSDebug
 
 on:
-  push:
-    branches: [ development ]
-  pull_request:
-    branches: [ development ]
-    if: github.event.pull_request.draft == false
   workflow_dispatch:
     inputs:
       debug_enabled:

--- a/.github/workflows/macdebug.yml
+++ b/.github/workflows/macdebug.yml
@@ -1,0 +1,60 @@
+name: CMake
+
+on:
+  push:
+    branches: [ development ]
+  pull_request:
+    branches: [ development ]
+    if: github.event.pull_request.draft == false
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
+        required: false
+        default: false
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+  OMP_NUM_THREADS: 2
+  CONAN_PRINT_RUN_COMMANDS: 1
+  CONAN_CPU_COUNT: 2
+
+jobs:
+  build:
+    name: macos-clang-debug
+    # The CMake configure and build commands are platform agnostic and should work equally
+    # well on Windows or Mac.  You can convert this to a matrix build if you need
+    # cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: macos-11
+    env:
+      CC: clang
+      CXX: clang++
+
+    steps:
+    - uses: actions/checkout@v2
+
+   # Enable tmate debugging of manually-triggered workflows if the input option was provided
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+      if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
+
+    - name: Install Dependencies on MacOS
+      if: ${{ contains(matrix.os, 'macos') }}
+      run: brew install libtiff open-mpi libyaml ccache conan
+
+    - name: Conan install on apple-clang
+      if: ${{ contains(matrix.cxx, 'clang++') }}
+      run: conan install ${{github.workspace}} -if ${{github.workspace}}/build --build missing -o mpi=on -o openmp=on
+
+    - name: Build
+      # Build your program with the given configuration.
+      # The Github Actions machines are dual-core so we can build faster using 2 parallel processes
+      run: conan build ${{github.workspace}} -bf ${{github.workspace}}/build
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      # Execute tests defined by the CMake configuration.
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest -C ${{env.BUILD_TYPE}} --output-on-failure

--- a/cmake_files/dependencies.cmake
+++ b/cmake_files/dependencies.cmake
@@ -22,7 +22,7 @@ endif()
 if(openmp)
   find_package(OpenMP)
   if(OPENMP_FOUND)
-    set(SOPT_DEFAULT_OPENMP_THREADS 4 CACHE STRING "Number of threads used in testing")
+    set(SOPT_DEFAULT_OPENMP_THREADS 2 CACHE STRING "Number of threads used in testing")
     set(SOPT_OPENMP TRUE)
     add_library(openmp::openmp INTERFACE IMPORTED GLOBAL)
     set_target_properties(openmp::openmp PROPERTIES

--- a/cpp/sopt/wavelets/sara.h
+++ b/cpp/sopt/wavelets/sara.h
@@ -11,9 +11,6 @@
 #ifdef SOPT_MPI
 #include "sopt/mpi/communicator.h"
 #endif
-#ifdef SOPT_OPENMP
-#include <omp.h>
-#endif
 
 namespace sopt {
 namespace wavelets {


### PR DESCRIPTION
Working on fixing some issues in CI. 

Adds an option to manually run the cmake workflow with a tmate session open so that you can ssh into it. I could not get the GitHub GUI to do what is suggested [here](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow), but I was able to run the workflow by installing the [gh CLI](https://docs.github.com/en/github-cli/github-cli/about-github-cli) and using it with

```
gh workflow run cmake.yml -f debug_enabled=true --ref tk/tmate
```

Closes #282.  The problem was `clang++` was ignoring the `-fopenmp` flag when building `wavelets/sara.cc`. This problem did not seem to occur in any other source files, and I was able to compile a [OpenMP hello world program](https://www.geeksforgeeks.org/openmp-hello-world-program/) on the runner after ssh'ing into it. `wavelets/sara.cc` does not seem to use any OpenMP pragmas or functions in any of the headers it includes, so in the end I just removed the unnecessary include from `sara.h` and it seems to have resolved the issue. 

Added `apt update` before `apt install` in the GA Ubuntu workflows. This was causing failures on ubuntu builds. Possibly related to the release of 22.04, at least the errors appeared around the same time.

Added a separate workflow for debugging MacOS problems to avoid running the whole matrix when debugging. This will not run by default, it must be ran manually, like the cmake workflow with tmate I described above.

After discussion with @jasonmcewen on June 7, removes MPI builds on MacOS from the CI matrix to make it lighter.