### PR TITLE
Fix OpenMP not found on MacOS GA

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -19,6 +19,7 @@ env:
   OMP_NUM_THREADS: 2
   CONAN_PRINT_RUN_COMMANDS: 1
   CONAN_CPU_COUNT: 2
+  CMAKE_PREFIX_PATH: "/usr/local/opt/libomp"
 
 jobs:
   build:
@@ -80,7 +81,6 @@ jobs:
       if: ${{ contains(matrix.os, 'macos') }}
       run: |
         brew update
-        brew upgrade
         brew install libtiff open-mpi libyaml ccache conan
 
     - name: Prepare ccache timestamp

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -19,7 +19,6 @@ env:
   OMP_NUM_THREADS: 2
   CONAN_PRINT_RUN_COMMANDS: 1
   CONAN_CPU_COUNT: 2
-  CMAKE_PREFIX_PATH: "/usr/local/opt/libomp" 
 
 jobs:
   build:
@@ -82,6 +81,7 @@ jobs:
       run: |
         brew update
         brew install libtiff open-mpi libyaml ccache conan
+        echo "{CMAKE_PREFIX_PATH}={/usr/local/opt/libomp}" >> $GITHUB_ENV
 
     - name: Prepare ccache timestamp
       id: ccache_cache_timestamp

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -114,9 +114,7 @@ jobs:
     - name: Build
       # Build your program with the given configuration.
       # The Github Actions machines are dual-core so we can build faster using 2 parallel processes
-      run: |
-        echo ${{env.CMAKE_PREFIX_PATH}}
-        conan build ${{github.workspace}} -bf ${{github.workspace}}/build 
+      run: conan build ${{github.workspace}} -bf ${{github.workspace}}/build
 
     - name: Test
       working-directory: ${{github.workspace}}/build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -50,7 +50,6 @@ jobs:
             - "on"
             - "off"
           exclude:
-            - os: ubuntu-20.04
             - cc: gcc-9
               cxx: clang++
             - cc: clang

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -19,7 +19,7 @@ env:
   OMP_NUM_THREADS: 2
   CONAN_PRINT_RUN_COMMANDS: 1
   CONAN_CPU_COUNT: 2
-  CMAKE_PREFIX_PATH: "/usr/local/opt/libomp"
+  CMAKE_PREFIX_PATH: "/usr/local/opt/libomp" 
 
 jobs:
   build:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -81,7 +81,7 @@ jobs:
       run: |
         brew update
         brew install libtiff open-mpi libyaml ccache conan
-        echo "{CMAKE_PREFIX_PATH}={/usr/local/opt/libomp}" >> $GITHUB_ENV
+        echo "CMAKE_PREFIX_PATH=/usr/local/opt/libomp" >> $GITHUB_ENV
 
     - name: Prepare ccache timestamp
       id: ccache_cache_timestamp
@@ -114,7 +114,9 @@ jobs:
     - name: Build
       # Build your program with the given configuration.
       # The Github Actions machines are dual-core so we can build faster using 2 parallel processes
-      run: conan build ${{github.workspace}} -bf ${{github.workspace}}/build 
+      run: |
+        echo ${{env.CMAKE_PREFIX_PATH}}
+        conan build ${{github.workspace}} -bf ${{github.workspace}}/build 
 
     - name: Test
       working-directory: ${{github.workspace}}/build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -36,7 +36,7 @@ jobs:
       matrix:
           os:
             - ubuntu-20.04
-            - macos-12
+            - macos-11
           cc:
             - gcc-9
             - clang
@@ -58,7 +58,7 @@ jobs:
             - os: ubuntu-20.04
               cc: clang
               cxx: clang++
-            - os: macos-12
+            - os: macos-11
               mpi: "on"
 
     steps:
@@ -80,6 +80,7 @@ jobs:
       if: ${{ contains(matrix.os, 'macos') }}
       run: |
         brew update
+        brew upgrade
         brew install libtiff open-mpi libyaml ccache conan
 
     - name: Prepare ccache timestamp

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -36,7 +36,7 @@ jobs:
       matrix:
           os:
             - ubuntu-20.04
-            - macos-11
+            - macos-12
           cc:
             - gcc-9
             - clang
@@ -50,6 +50,7 @@ jobs:
             - "on"
             - "off"
           exclude:
+            - os: ubuntu-20.04
             - cc: gcc-9
               cxx: clang++
             - cc: clang
@@ -57,7 +58,7 @@ jobs:
             - os: ubuntu-20.04
               cc: clang
               cxx: clang++
-            - os: macos-11
+            - os: macos-12
               mpi: "on"
 
     steps:


### PR DESCRIPTION
Closes #308 

In the end the problem was cmake was not looking for `libomp` in the path that brew installed it to. I hard-coded the path in the install step for apple clang in an environment variable and cmake is happy again.