### PR TITLE
Fix MacOS CI issues

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -80,7 +80,7 @@ jobs:
       run: |
         brew update
         brew install libtiff open-mpi libyaml ccache
-        pip install conan
+        pip3 install conan
         echo "CMAKE_PREFIX_PATH=/usr/local/opt/libomp" >> $GITHUB_ENV
 
     - name: Prepare ccache timestamp

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -79,7 +79,8 @@ jobs:
       if: ${{ contains(matrix.os, 'macos') }}
       run: |
         brew update
-        brew install libtiff open-mpi libyaml ccache conan
+        brew install libtiff open-mpi libyaml ccache
+        pip install conan
         echo "CMAKE_PREFIX_PATH=/usr/local/opt/libomp" >> $GITHUB_ENV
 
     - name: Prepare ccache timestamp

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -73,16 +73,21 @@ jobs:
       run: |
         sudo apt update
         sudo apt install libtiff5-dev openmpi-bin libopenmpi-dev libeigen3-dev libyaml-cpp-dev ccache
-        pip install conan
 
     - name: Install Dependencies on MacOS
       if: ${{ contains(matrix.os, 'macos') }}
       run: |
         brew update
         brew install libtiff open-mpi libyaml ccache
-        pip3 install conan
         echo "CMAKE_PREFIX_PATH=/usr/local/opt/libomp" >> $GITHUB_ENV
 
+    - name: Install Conan
+      id: conan
+      uses: turtlebrowser/get-conan@main
+
+    - name: Conan version
+      run: echo "${{ steps.conan.outputs.version }}"
+        
     - name: Prepare ccache timestamp
       id: ccache_cache_timestamp
       shell: cmake -P {0}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -81,6 +81,13 @@ jobs:
         brew install libtiff open-mpi libyaml ccache
         echo "CMAKE_PREFIX_PATH=/usr/local/opt/libomp" >> $GITHUB_ENV
 
+    - name: Select Python 3.10
+      # otherwise turtlebrowser/get-conan@v1.1 fails on macos-12
+      # ref: https://github.com/turtlebrowser/get-conan/issues/4
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+        
     - name: Install Conan
       id: conan
       uses: turtlebrowser/get-conan@main


### PR DESCRIPTION
Fix #282 

Changes the conan installation to a portable action from the GitHub marketplace. Under the hood it seems to use `pip3` so not much will change on Ubuntu, but should be consistent on MacOS as well. Added workaround suggested in https://github.com/turtlebrowser/get-conan/issues/4 to get around conan not installing on MacOS runners. This has to do with the runners having updated their python to 3.11. I assume this will eventually get fixed in the action and we can remove the extra `Select Python 3.10` step.