### PR TITLE
Fix tests failing on MacOS

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -91,6 +91,8 @@ jobs:
     - name: Install Conan
       id: conan
       uses: turtlebrowser/get-conan@main
+      with:
+        version: 1.54.0
 
     - name: Conan version
       run: echo "${{ steps.conan.outputs.version }}"


### PR DESCRIPTION
There's a bug in the `libdeflate` package in conan 1.55, discussed in this [issue](https://github.com/conan-io/conan-center-index/issues/14545). As a work around until they merge https://github.com/conan-io/conan-center-index/pull/14548, this PR will install conan version 1.54 on GHA 