### PR TITLE
Use latest conan version

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -79,7 +79,8 @@ jobs:
     - name: Install Dependencies on MacOS
       if: ${{ contains(matrix.os, 'macos') }}
       run: |
-        brew update
+        # Skip brew update until https://github.com/actions/setup-python/issues/577 is fixed
+        # brew update
         brew install libtiff open-mpi libyaml ccache
         echo "CMAKE_PREFIX_PATH=/usr/local/opt/libomp" >> $GITHUB_ENV
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -108,8 +108,6 @@ jobs:
     - name: Install Conan
       id: conan
       uses: turtlebrowser/get-conan@main
-      with:
-        version: 1.54.0
 
     - name: Conan version
       run: echo "${{ steps.conan.outputs.version }}"


### PR DESCRIPTION
The issue in conan that we added a work-around for in #319 has been fixed on conan side. We can go back to using the latest version.