### PR TITLE
Add g_proximal method to other classes and general bug hunting 

### DIFF
--- a/cpp/sopt/cppflow_utils.cc
+++ b/cpp/sopt/cppflow_utils.cc
@@ -9,7 +9,8 @@
 namespace sopt {
 namespace cppflowutils {
 
-  const double imaginary_threshold = 1e-5;
+  // arbitrary constant for imaginary part of image vectors. 
+  const double imaginary_threshold = 1e-10;
 
     cppflow::tensor convert_image_to_tensor(Image<double> const &image, int image_rows, int image_cols){
         // Convert the Sopt::Image of doubles(wrapper for Eigen::Array) to a cppflow::tensor of floats
@@ -42,7 +43,7 @@ namespace cppflowutils {
 
     for (int i = 0; i < image.rows(); ++i) {
         for (int j = 0; j < image.cols(); ++j) {
-          if(std::abs(image(i,j).imag())/std::abs(image(i,j).real()) > cppflowutils::imaginary_threshold)
+          if(std::abs(image(i,j).real()) > cppflowutils::imaginary_threshold)
           {
             throw std::runtime_error("Cannot convert to tensorflow format: imaginary component of image is non-negligible.");
           }
@@ -71,7 +72,7 @@ namespace cppflowutils {
     std::vector<float> input_values(image_rows);
     for(int i = 0; i < image_rows; i++)
     {
-      if(std::abs(image(i).imag())/std::abs(image(i).real()) > cppflowutils::imaginary_threshold)
+      if(std::abs(image(i).real()) > cppflowutils::imaginary_threshold)
       {
         throw std::runtime_error("Cannot conver to tensorflow format: imaginary component of image vector is non negligible.");
       }

--- a/cpp/sopt/cppflow_utils.cc
+++ b/cpp/sopt/cppflow_utils.cc
@@ -4,9 +4,13 @@
 #include <cppflow/cppflow.h>
 #include "cppflow/ops.h"
 #include "cppflow/model.h"
+#include <stdexcept>
 
 namespace sopt {
 namespace cppflowutils {
+
+  const double imaginary_threshold = 1e-5;
+
     cppflow::tensor convert_image_to_tensor(Image<double> const &image, int image_rows, int image_cols){
         // Convert the Sopt::Image of doubles(wrapper for Eigen::Array) to a cppflow::tensor of floats
         // TODO: Make types template parameters
@@ -16,7 +20,7 @@ namespace cppflowutils {
         std::vector<float> input_values(image_rows*image_cols, 1);
         for (int i = 0; i < image.rows(); ++i) {
             for (int j = 0; j < image.cols(); ++j) {
-            input_values[j*image_cols+i] = image(i,j);
+              input_values[j*image_cols+i] = image(i,j);
             }
         }
 
@@ -26,14 +30,56 @@ namespace cppflowutils {
         return input_tensor;
     }
 
+  cppflow::tensor convert_image_to_tensor(Image<std::complex<double>> const &image, int image_rows, int image_cols) {
+    // Convert the Sopt::Image of complex (wrapper for Eigen::Array) to a cppflow::tensor of floats
+    // Only takes the real part for processing, on the assumption that the imaginary part is negligible.
+    // If ratio of imaginary part to real part is greater than the threshold then this will throw an exception.
+    // TODO: Make types template parameters
+    // create a vector of the right shape (model expects extra dimensions on start and end)
+    std::vector<int64_t> input_shape = {1, image_rows, image_cols, 1};
+
+    std::vector<float> input_values(image_rows*image_cols, 1);
+
+    for (int i = 0; i < image.rows(); ++i) {
+        for (int j = 0; j < image.cols(); ++j) {
+          if(std::abs(image(i,j).imag())/std::abs(image(i,j).real()) > cppflowutils::imaginary_threshold)
+          {
+            throw std::runtime_error("Cannot convert to tensorflow format: imaginary component of image is non-negligible.");
+          }
+          input_values[j*image_cols+i] = image(i,j).real();
+        }
+    }
+
+    // create a tensor from vector
+    cppflow::tensor input_tensor(input_values, input_shape);
+    return input_tensor;
+  }
+
   // Convert an image stored in a sopt::Vector<double> to a cppflow::tensor of floats
   cppflow::tensor convert_image_to_tensor(sopt::Vector<double> const &image, int image_rows, int image_cols) {
 
-    std::vector<float> values(&image[0], image.data()+image.size());
-    cppflow::tensor input_tensor(values, {1, image_rows, image_cols, 1});
+    std::vector<float> input_values(&image[0], image.data()+image.size());
+    cppflow::tensor input_tensor(input_values, {1, image_rows, image_cols, 1});
 
     return input_tensor;
 
+  }
+
+  // Convert an image stored in a sopt::Vector<double> to a cppflow::tensor of floats
+  cppflow::tensor convert_image_to_tensor(sopt::Vector<std::complex<double>> const &image, int image_rows, int image_cols) {
+
+    std::vector<float> input_values(image_rows);
+    for(int i = 0; i < image_rows; i++)
+    {
+      if(std::abs(image(i).imag())/std::abs(image(i).real()) > cppflowutils::imaginary_threshold)
+      {
+        throw std::runtime_error("Cannot conver to tensorflow format: imaginary component of image vector is non negligible.");
+      }
+      input_values[i] = image(i).real();
+    }
+    cppflow::tensor input_tensor(input_values, {1, image_rows, image_cols, 1});
+
+    return input_tensor;
   }
 
   // Convert model output in a std::vector into a sopt::Image (2D Eigen::Array)

--- a/cpp/sopt/cppflow_utils.h
+++ b/cpp/sopt/cppflow_utils.h
@@ -5,13 +5,17 @@
 #include "sopt/types.h"
 #include <cppflow/cppflow.h>
 #include "cppflow/ops.h"
+#include <complex>
 
 namespace sopt {
 namespace cppflowutils {
+
 //! Converts a sopt::Image to a cppflow::tensor
 cppflow::tensor convert_image_to_tensor(sopt::Image<double> const &image, int image_rows, int image_cols);
+cppflow::tensor convert_image_to_tensor(sopt::Image<std::complex<double>> const &image, int image_rows, int image_cols);
 //! Converts a sopt::Vector to a cppflow::tensor
 cppflow::tensor convert_image_to_tensor(sopt::Vector<double> const &image, int image_rows, int image_cols);
+cppflow::tensor convert_image_to_tensor(sopt::Vector<std::complex<double>> const &image, int image_rows, int image_cols);
 
 //! Convert a cppflow:tensor to an Eigen::Array
 Eigen::Map<Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic>> convert_tensor_to_image(std::vector<float> model_output, int image_rows, int image_cols);

--- a/cpp/sopt/gradient_operator.h
+++ b/cpp/sopt/gradient_operator.h
@@ -49,7 +49,7 @@ template <class T>
 LinearTransform<Vector<T>> gradient_operator(const t_int rows, const t_int cols) {
   return LinearTransform<Vector<T>>(
       [rows, cols](Vector<T> &out, Vector<T> const &x) {
-        assert(x.size() = rows * cols * 2);
+        assert(x.size() == rows * cols * 2);
         out = diff2d_adjoint(x, rows, cols) / 2.;
         assert(out.size() == rows * cols);
       },

--- a/cpp/sopt/imaging_forward_backward.h
+++ b/cpp/sopt/imaging_forward_backward.h
@@ -125,6 +125,7 @@ class ImagingForwardBackward {
 #ifdef SOPT_MPI
   //! Communicator for summing objective_function
   SOPT_MACRO(obj_comm, mpi::Communicator);
+  SOPT_MACRO(adjoint_space_comm, mpi::Communicator);
 #endif
 
 #undef SOPT_MACRO
@@ -205,7 +206,7 @@ class ImagingForwardBackward {
 
   //! \brief Proximal of the L2 ball
   //! \details Non-const version to setup the object.
-  t_Gradient &l2_graident() { return l2_gradient_; }
+  t_Gradient &l2_gradient() { return l2_gradient_; }
 
   //! Helper function to set-up default residual convergence function
   ImagingForwardBackward<Scalar> &residual_convergence(Real const &tolerance) {
@@ -316,7 +317,7 @@ bool ImagingForwardBackward<SCALAR>::objective_convergence(mpi::Communicator con
   if (scalvar.relative_tolerance() <= 0e0) return true;
   auto const current = obj_comm.all_sum_all<t_real>(
 	((gamma() > 0) ? g_proximal_->proximal_norm(x)
-       * gamma() : 0) + std::pow(sopt::l2_norm(residual), 2) / (2 * sigma() * sigma()));
+       * gamma() : 0) + std::pow(sopt::l2_norm(residual), 2) / (2 * sigma_ * sigma_));
   return scalvar(current);
 };
 #endif

--- a/cpp/sopt/imaging_padmm.h
+++ b/cpp/sopt/imaging_padmm.h
@@ -83,6 +83,11 @@ class ImagingProximalADMM {
                                                         \
  public:
 
+  proximal::L1<Scalar> * g_proximal()
+  {
+    return &l1_proximal_;
+  }
+
   //! Maximum number of iterations
   SOPT_MACRO(l1_proximal, proximal::L1<Scalar>);
   //! The weighted L2 proximal functioning as g

--- a/cpp/sopt/imaging_primal_dual.h
+++ b/cpp/sopt/imaging_primal_dual.h
@@ -94,6 +94,7 @@ class ImagingPrimalDual {
   TYPE NAME##_;                                       \
                                                       \
  public:
+  ImagingPrimalDual * g_proximal(){ return this;}
   //! The l1 prox functioning as f
   SOPT_MACRO(l1_proximal, t_Proximal<Real>);
   //! The l1 prox with weights functioning as f

--- a/cpp/sopt/l1_g_proximal.h
+++ b/cpp/sopt/l1_g_proximal.h
@@ -49,7 +49,9 @@ public:
 
   // Return the norm associated with this implementation
   Real proximal_norm(t_Vector const &x) const override {
-    return sopt::l1_norm(static_cast<t_Vector>(Psi().adjoint() * x), l1_proximal_weights());
+    auto &weights = l1_proximal_weights();
+    auto input = static_cast<t_Vector>(Psi().adjoint() * x);
+    return sopt::l1_norm(input, weights);
   }
 
   // Return g_proximal as a lambda function. Used in operator() in base class.
@@ -97,7 +99,7 @@ public:
   SOPT_MACRO(positivity_constraint, bool);
   SOPT_MACRO(real_constraint, bool);
   SOPT_MACRO(nu, Real);
-  SOPT_MACRO(weights, t_Vector);
+  SOPT_MACRO(weights, Vector<t_real>);
 #undef SOPT_MACRO
 
   //! Analysis operator Ψ

--- a/cpp/sopt/l1_g_proximal.h
+++ b/cpp/sopt/l1_g_proximal.h
@@ -15,6 +15,10 @@
 #include "sopt/g_proximal.h"
 #include "sopt/l1_proximal.h"
 
+#ifdef SOPT_MPI
+ #include "sopt/mpi/communicator.h"
+#endif
+
 namespace sopt {
 namespace algorithm {
 
@@ -100,6 +104,10 @@ public:
   SOPT_MACRO(real_constraint, bool);
   SOPT_MACRO(nu, Real);
   SOPT_MACRO(weights, Vector<t_real>);
+#ifdef SOPT_MPI
+  SOPT_MACRO(adjoint_space_comm, mpi::Communicator);
+  SOPT_MACRO(direct_space_comm, mpi::Communicator);
+#endif
 #undef SOPT_MACRO
 
   //! Analysis operator Ψ

--- a/cpp/sopt/l2_forward_backward.h
+++ b/cpp/sopt/l2_forward_backward.h
@@ -206,7 +206,7 @@ class L2ForwardBackward {
   t_Proximal<Vector<Real>> &l2_proximal_weighted() { return l2_proximal_weighted_; }
   //! \brief Proximal of the L2 ball
   //! \details Non-const version to setup the object.
-  t_Gradient &l2_graident() { return l2_gradient_; }
+  t_Gradient &l2_gradient() { return l2_gradient_; }
 
   //! Helper function to set-up default residual convergence function
   L2ForwardBackward<Scalar> &residual_convergence(Real const &tolerance) {


### PR DESCRIPTION
Primal Dual and PADMM have g_proximal functions which point to the object which holds the relevant members like Psi(). This is a bit of a patch though to get things to compile and work as these classes have not been fully refactored into this style! 

Complex type issues are addressed by converting complex images into real images for tensorflow. 
Seg-faulting fixed and MPI has been added to the L1Gproximal class.

 