### PR TITLE
Initial effort to incorporate modern practices in top-level CMakeLists file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,4 @@ build/
 python/tests/__pycache__
 *.h.gch
 *~
+compile_commands.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,23 @@
-cmake_minimum_required(VERSION 3.0)
-project(Sopt CXX)
+cmake_minimum_required(VERSION 3.13.4) # CMake 3.13.4 is the currently default in Debian 10 repositories
+project(Sopt
+        DESCRIPTION "Sparse OPTimisation using state-of-the-art convex optimisation algorithms."
+        HOMEPAGE_URL "https://github.com/sopt/sopt"
+        LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# https://cmake.org/cmake/help/latest/variable/CMAKE_EXPORT_COMPILE_COMMANDS.html
+# Enable output of compile commands during generation. If enabled, generates a compile_commands.json file containing the exact compiler calls for all translation units of the project in machine-readable form. This can be consumed by various IDEs and static analysers to provide smarter project diagnostics/completions etc.
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# https://stackoverflow.com/a/67410042
+# Create a symlink to compile_commands.json located in CMAKE_BINARY_DIR to the project root (works across filesystems)
+execute_process(
+  COMMAND ${CMAKE_COMMAND} -E create_symlink
+  ${CMAKE_BINARY_DIR}/compile_commands.json
+  ${CMAKE_SOURCE_DIR}/compile_commands.json)
 
 # Location of extra cmake includes for the project
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake_files)
@@ -33,11 +51,7 @@ if(tests)
   enable_testing()
 endif()
 
-# Add c++11 stuff
-#include(AddCPP11Flags)
-set(CMAKE_CXX_STANDARD 17)
-include(CheckCXX11Features)
-cxx11_feature_check(REQUIRED unique_ptr override)
+
 include(compilations)
 
 # search/install dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13.4) # CMake 3.13.4 is the currently default in Debian 10 repositories
 project(Sopt
         DESCRIPTION "Sparse OPTimisation using state-of-the-art convex optimisation algorithms."
-        HOMEPAGE_URL "https://github.com/sopt/sopt"
+        HOMEPAGE_URL "http://astro-informatics.github.io/sopt/"
         LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)


### PR DESCRIPTION
Shall close #373.

- changes minimum cmake required version to 3.13.4 (default from the repos of oldest supported Debian as of June 2023)
- adds project description and homepage url
- explicitly sets the LANGUAGES keyword in the project() command as recommended in best practice guides
- enforces language standard to C++17
- disables compiler-specific extensions that are otherwise enabled by default in CMake
- exports the compilation database of the project (compile_commands.json) into CMAKE_BINARY_DIR
- adds a custom command to symlink (in a filesystem-agnostic manner) the compilation database from CMAKE_BINARY_DIR to PROJECT_SOURCE_DIR to be picked up by IDEs and static analysers. Requires at least cmake version 3.13.x for true cross-platform support (i.e. Windows support). See the official documentation [here](https://cmake.org/cmake/help/latest/manual/cmake.1.html#cmdoption-cmake-E-arg-create_symlink) and [here](https://cmake.org/cmake/help/latest/release/3.13.html#command-line).
- adds compile_commands.json to .gitignore
_____________________________________________

Additional background reading/information

## 1. Compilation database
See the official documentation [here](https://clang.llvm.org/docs/JSONCompilationDatabase.html) from the LLVM project. Quoting some key excerpts verbatim below (emphasis mine):

> Tools based on the C++ Abstract Syntax Tree need full information how to parse a translation unit. Usually this information is **implicitly available in the build system**
>
> #### Format
> 
> A compilation database is a JSON file, which consist of an array of “command objects”, where each command object specifies one way a translation unit is compiled in the project.
> 
> Each command object contains the translation unit’s main file, the working directory of the compile run and the actual compile command.
>
> #### Build System Integration
> 
> The convention is to name the file **compile_commands.json** and put it at the top of the build directory. Clang tools are pointed to the top of the build directory to detect the file and use the compilation database to parse C++ code in the source tree.

Additional links (I vetted these based on simplicity/readability):
- https://sarcasm.github.io/notes/dev/compilation-database.html
- https://devblogs.microsoft.com/cppblog/visual-studio-code-cc-extension-october-2017-update/#compile_commands-json-to-supply-includes-and-defines-information-for-intellisense
- https://devblogs.microsoft.com/cppblog/makefile-tools-december-2021-update-problem-matchers-and-compilation-database-generation/#generate-compile_commands-json
- https://pvs-studio.com/en/docs/manual/6557/
- https://www.sonarsource.com/blog/alternative-way-to-configure-c-and-cpp-analysis/
- [Slightly outdated information, but okay as a high-level read](https://eli.thegreenplace.net/2014/05/21/compilation-databases-for-clang-based-tools)

## 2. CMake's behaviour in setting language standard

As per the [documentation of the `CXX_STANDARD`](https://cmake.org/cmake/help/latest/prop_tgt/CXX_STANDARD.html) variable:
> If the value requested does not result in a compile flag being added for the compiler in use, a **previous standard flag** will be added instead. This means that using:
> 
> ```
> set_property(TARGET tgt PROPERTY CXX_STANDARD 11)
> ```
> with a compiler which does not support -std=gnu++11 or an equivalent flag will **not** result in an error or warning, but will instead add the **-std=gnu++98** flag if supported. **This "decay" behavior** may be controlled with the [**CXX_STANDARD_REQUIRED**](https://cmake.org/cmake/help/latest/prop_tgt/CXX_STANDARD_REQUIRED.html#prop_tgt:CXX_STANDARD_REQUIRED) target property. Additionally, the [**CXX_EXTENSIONS**](https://cmake.org/cmake/help/latest/prop_tgt/CXX_EXTENSIONS.html#prop_tgt:CXX_EXTENSIONS) target property may be used to control whether **compiler-specific extensions are enabled** on a per-target basis.

Prior to this commit:
- Compiler-specific extensions were enabled (this is cmake's default behaviour). Please refer to the [official documentation](https://cmake.org/cmake/help/latest/prop_tgt/CXX_EXTENSIONS.html#prop_tgt:CXX_EXTENSIONS) for further info.
- Although we had asked CMake to give us the C++17 standard, it is likely that it decayed to a previous standard.  Please refer to the [official documentation](https://cmake.org/cmake/help/latest/prop_tgt/CXX_STANDARD_REQUIRED.html#prop_tgt:CXX_STANDARD_REQUIRED) for further information on this decay behaviour.