### PR TITLE
updates .gitignore with more ignore entries for C++/CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,53 @@ build/
 python/tests/__pycache__
 *.h.gch
 *~
+
+### CMake ###
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+
+# CMake External projects (created by CMake fetchcontent module)
+*-prefix/
+
+### C++ ###
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app


### PR DESCRIPTION
Updates the project's `.gitignore` file with more ignore patterns from [here](https://www.toptal.com/developers/gitignore/) and [here](https://github.com/github/gitignore) for C++ and CMake projects (these two sources have mostly identical ignore patterns).