### PR TITLE
Concatenates nested namespaces (capability introduced in C++17 std)

### DIFF
--- a/cpp/sopt/config.in.h
+++ b/cpp/sopt/config.in.h
@@ -45,6 +45,6 @@ inline constexpr bool color_logger() { return @SOPT_COLOR_LOGGING@; }
 //! Number of threads used during testing
 inline constexpr std::size_t number_of_threads_in_tests() { return @SOPT_DEFAULT_OPENMP_THREADS@; }
 # endif
-}
+} // namespace sopt
 
 #endif

--- a/cpp/sopt/cppflow_utils.cc
+++ b/cpp/sopt/cppflow_utils.cc
@@ -6,10 +6,9 @@
 #include "cppflow/model.h"
 #include <stdexcept>
 
-namespace sopt {
-namespace cppflowutils {
+namespace sopt::cppflowutils {
 
-  // arbitrary constant for imaginary part of image vectors. 
+  // arbitrary constant for imaginary part of image vectors.
   const double imaginary_threshold = 1e-10;
 
     cppflow::tensor convert_image_to_tensor(Image<double> const &image, int image_rows, int image_cols){
@@ -93,5 +92,4 @@ namespace cppflowutils {
     return output_image;
   }
 
-}  // namespace cppflowutils
-}  // namespace sopt
+} // namespace sopt::cppflowutils

--- a/cpp/sopt/cppflow_utils.h
+++ b/cpp/sopt/cppflow_utils.h
@@ -7,8 +7,7 @@
 #include "cppflow/ops.h"
 #include <complex>
 
-namespace sopt {
-namespace cppflowutils {
+namespace sopt::cppflowutils {
 
 //! Converts a sopt::Image to a cppflow::tensor
 cppflow::tensor convert_image_to_tensor(sopt::Image<double> const &image, int image_rows, int image_cols);
@@ -20,6 +19,5 @@ cppflow::tensor convert_image_to_tensor(sopt::Vector<std::complex<double>> const
 //! Convert a cppflow:tensor to an Eigen::Array
 Eigen::Map<Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic>> convert_tensor_to_image(std::vector<float> model_output, int image_rows, int image_cols);
 
-}  // namespace cppflowutils
-}  // namespace sopt
+} // namespace sopt::cppflowutils
 #endif

--- a/cpp/sopt/credible_region.h
+++ b/cpp/sopt/credible_region.h
@@ -10,8 +10,7 @@
 #include "sopt/logging.h"
 #include "sopt/types.h"
 
-namespace sopt {
-namespace credible_region {
+namespace sopt::credible_region {
 
 template <class T>
 t_real compute_energy_upper_bound(
@@ -54,11 +53,9 @@ credible_interval(const Eigen::MatrixBase<T> &solution, const t_uint &rows, cons
                   const std::tuple<t_uint, t_uint> &grid_pixel_size,
                   const std::function<t_real(typename T::PlainObject)> &objective_function,
                   const t_real &alpha);
-}  // namespace credible_region
-}  // namespace sopt
+} // namespace sopt::credible_region
 
-namespace sopt {
-namespace credible_region {
+namespace sopt::credible_region {
 
 template <class T>
 t_real compute_energy_upper_bound(
@@ -197,8 +194,6 @@ credible_interval(const Eigen::MatrixBase<T> &solution, const t_uint &rows, cons
   return credible_interval_grid<typename T::PlainObject, K>(solution, rows, cols, grid_pixel_size,
                                                             objective_function, energy_upperbound);
 }
-}  // namespace credible_region
-
-}  // namespace sopt
+} // namespace sopt::credible_region
 
 #endif

--- a/cpp/sopt/forward_backward.h
+++ b/cpp/sopt/forward_backward.h
@@ -9,8 +9,7 @@
 #include "sopt/logging.h"
 #include "sopt/types.h"
 
-namespace sopt {
-namespace algorithm {
+namespace sopt::algorithm {
 
 //! \brief Forward Backward Splitting
 //! \details \f$\min_{x} f(\Phi x - y) + g(z)\f$. \f$y\f$ is a target vector.
@@ -282,6 +281,5 @@ typename ForwardBackward<SCALAR>::Diagnostic ForwardBackward<SCALAR>::operator()
   }
   return {niters, converged, std::move(residual)};
 }
-}  // namespace algorithm
-}  // namespace sopt
+} // namespace sopt::algorithm
 #endif

--- a/cpp/sopt/gradient_operator.h
+++ b/cpp/sopt/gradient_operator.h
@@ -5,8 +5,7 @@
 #include "sopt/linear_transform.h"
 #include "sopt/logging.h"
 
-namespace sopt {
-namespace gradient_operator {
+namespace sopt::gradient_operator {
 //! Numerical derivative of 1d vector
 template <class T>
 Vector<T> diff(const Vector<T> &x) {
@@ -61,7 +60,6 @@ LinearTransform<Vector<T>> gradient_operator(const t_int rows, const t_int cols)
       },
       {{0, 1, static_cast<t_int>(2 * rows * cols)}});
 }
-}  // namespace gradient_operator
-}  // namespace sopt
+} // namespace sopt::gradient_operator
 
 #endif

--- a/cpp/sopt/imaging_forward_backward.h
+++ b/cpp/sopt/imaging_forward_backward.h
@@ -19,8 +19,7 @@
 #include "sopt/mpi/utilities.h"
 #endif
 
-namespace sopt {
-namespace algorithm {
+namespace sopt::algorithm {
 template <class SCALAR>
 class ImagingForwardBackward {
   //! Underlying algorithm
@@ -337,6 +336,5 @@ bool ImagingForwardBackward<SCALAR>::is_converged(ScalarRelativeVariation<Scalar
   // better evaluate each convergence function everytime, especially with mpi
   return user and res and obj;
 }
-}  // namespace algorithm
-}  // namespace sopt
+} // namespace sopt::algorithm
 #endif

--- a/cpp/sopt/imaging_padmm.h
+++ b/cpp/sopt/imaging_padmm.h
@@ -14,8 +14,7 @@
 #include "sopt/relative_variation.h"
 #include "sopt/types.h"
 
-namespace sopt {
-namespace algorithm {
+namespace sopt::algorithm {
 template <class SCALAR>
 class ImagingProximalADMM {
   //! Underlying algorithm
@@ -346,6 +345,5 @@ bool ImagingProximalADMM<SCALAR>::is_converged(ScalarRelativeVariation<Scalar> &
   // better evaluate each convergence function everytime, especially with mpi
   return user and res and obj;
 }
-}  // namespace algorithm
-}  // namespace sopt
+} // namespace sopt::algorithm
 #endif

--- a/cpp/sopt/imaging_primal_dual.h
+++ b/cpp/sopt/imaging_primal_dual.h
@@ -14,8 +14,7 @@
 #include "sopt/relative_variation.h"
 #include "sopt/types.h"
 
-namespace sopt {
-namespace algorithm {
+namespace sopt::algorithm {
 template <class SCALAR>
 class ImagingPrimalDual {
   //! Underlying algorithm
@@ -394,6 +393,5 @@ bool ImagingPrimalDual<SCALAR>::is_converged(ScalarRelativeVariation<Scalar> &sc
   // better evaluate each convergence function everytime, especially with mpi
   return user and res and obj;
 }
-}  // namespace algorithm
-}  // namespace sopt
+} // namespace sopt::algorithm
 #endif

--- a/cpp/sopt/joint_map.h
+++ b/cpp/sopt/joint_map.h
@@ -11,8 +11,7 @@
 #include "sopt/logging.h"
 #include "sopt/types.h"
 
-namespace sopt {
-namespace algorithm {
+namespace sopt::algorithm {
 
 template <class ALGORITHM>
 class JointMAP {
@@ -135,7 +134,6 @@ class JointMAP {
   };
 };
 
-}  // namespace algorithm
-}  // namespace sopt
+} // namespace sopt::algorithm
 
 #endif

--- a/cpp/sopt/l1_g_proximal.h
+++ b/cpp/sopt/l1_g_proximal.h
@@ -19,8 +19,7 @@
  #include "sopt/mpi/communicator.h"
 #endif
 
-namespace sopt {
-namespace algorithm {
+namespace sopt::algorithm {
 
 // Implementation of g_proximal with l1 proximal.
 // Owns the private object l1_proximal_ and implements the
@@ -145,6 +144,5 @@ protected:
   }
 
 };
-}
-}
+} // namespace sopt::algorithm
 #endif

--- a/cpp/sopt/l1_proximal.h
+++ b/cpp/sopt/l1_proximal.h
@@ -13,8 +13,7 @@
 #include "sopt/mpi/utilities.h"
 #endif
 
-namespace sopt {
-namespace proximal {
+namespace sopt::proximal {
 
 //! \brief L1 proximal, including linear transform
 //! \details This function computes the prox operator of the l1
@@ -475,7 +474,6 @@ class L1<SCALAR>::Breaker {
   std::array<Real, 4> objectives;
   bool do_two_cycle;
 };
-}  // namespace proximal
-}  // namespace sopt
+} // namespace sopt::proximal
 
 #endif

--- a/cpp/sopt/l2_forward_backward.h
+++ b/cpp/sopt/l2_forward_backward.h
@@ -18,8 +18,7 @@
 #include "sopt/mpi/utilities.h"
 #endif
 
-namespace sopt {
-namespace algorithm {
+namespace sopt::algorithm {
 template <class SCALAR>
 class L2ForwardBackward {
   //! Underlying algorithm
@@ -337,6 +336,5 @@ bool L2ForwardBackward<SCALAR>::is_converged(ScalarRelativeVariation<Scalar> &sc
   // better evaluate each convergence function everytime, especially with mpi
   return user and res and obj;
 }
-}  // namespace algorithm
-}  // namespace sopt
+} // namespace sopt::algorithm
 #endif

--- a/cpp/sopt/l2_primal_dual.h
+++ b/cpp/sopt/l2_primal_dual.h
@@ -13,8 +13,7 @@
 #include "sopt/relative_variation.h"
 #include "sopt/types.h"
 
-namespace sopt {
-namespace algorithm {
+namespace sopt::algorithm {
 template <class SCALAR>
 class ImagingPrimalDual {
   //! Underlying algorithm
@@ -395,6 +394,5 @@ bool ImagingPrimalDual<SCALAR>::is_converged(ScalarRelativeVariation<Scalar> &sc
   // better evaluate each convergence function everytime, especially with mpi
   return user and res and obj;
 }
-}  // namespace algorithm
-}  // namespace sopt
+} // namespace sopt::algorithm
 #endif

--- a/cpp/sopt/logging.disabled.h
+++ b/cpp/sopt/logging.disabled.h
@@ -5,8 +5,7 @@
 #include <memory>
 #include <string>
 
-namespace sopt {
-namespace logging {
+namespace sopt::logging {
 //! Name of the sopt logger
 const std::string name_prefix = "sopt::";
 
@@ -17,8 +16,7 @@ inline std::shared_ptr<int> get() { return nullptr; }
 inline void set_level(std::string const &, std::string const &){};
 inline void set_level(std::string const &){};
 inline bool has_level(std::string const &, std::string const &) { return false; }
-}  // namespace logging
-}  // namespace sopt
+} // namespace sopt::logging
 
 //! \macro For internal use only
 #define SOPT_LOG_(...)

--- a/cpp/sopt/logging.enabled.h
+++ b/cpp/sopt/logging.enabled.h
@@ -7,8 +7,7 @@
 #include <spdlog/sinks/stdout_sinks.h>
 #include "sopt/exception.h"
 
-namespace sopt {
-namespace logging {
+namespace sopt::logging {
 void set_level(std::string const &level, std::string const &name = "");
 
 //! \brief Initializes a logger.
@@ -65,8 +64,7 @@ inline bool has_level(std::string const &level, std::string const &name = "") {
 #undef SOPT_MACRO
   else SOPT_THROW("Unknown logging level ") << level << "\n";
 }
-}  // namespace logging
-}  // namespace sopt
+} // namespace sopt::logging
 
 //! \macro For internal use only
 #define SOPT_LOG_(NAME, TYPE, ...)                                          \

--- a/cpp/sopt/mpi/communicator.cc
+++ b/cpp/sopt/mpi/communicator.cc
@@ -3,8 +3,7 @@
 #include <mpi.h>
 #include "sopt/mpi/session.h"
 
-namespace sopt {
-namespace mpi {
+namespace sopt::mpi {
 
 void Communicator::delete_comm(Communicator::Impl *const impl) {
   if (impl->comm != MPI_COMM_WORLD and impl->comm != MPI_COMM_SELF and impl->comm != MPI_COMM_NULL)
@@ -49,5 +48,4 @@ std::string Communicator::broadcast(std::string const &input, t_uint const root)
   return result;
 }
 
-}  // namespace mpi
-}  // namespace sopt
+} // namespace sopt::mpi

--- a/cpp/sopt/mpi/communicator.h
+++ b/cpp/sopt/mpi/communicator.h
@@ -19,8 +19,7 @@
 #include <cxxabi.h>
 #include <typeinfo>
 
-namespace sopt {
-namespace mpi {
+namespace sopt::mpi {
 
 //! \brief A C++ wrapper for an mpi communicator
 //! \details All copies made of this communicator are shallow: they reference
@@ -584,7 +583,6 @@ Communicator::broadcast(t_uint const root) const {
   MPI_Bcast(result.data(), result.size(), Type<typename T::value_type>::value, root, **this);
   return result;
 }
-}  // namespace mpi
-}  // namespace sopt
+} // namespace sopt::mpi
 #endif /* ifdef SOPT_MPI */
 #endif /* ifndef SOPT_MPI_COMMUNICATOR */

--- a/cpp/sopt/mpi/registered_types.cc
+++ b/cpp/sopt/mpi/registered_types.cc
@@ -1,7 +1,6 @@
 #include "sopt/mpi/registered_types.h"
 
-namespace sopt {
-namespace mpi {
+namespace sopt::mpi {
 MPIType const Type<std::int8_t>::value = MPI_INT8_T;
 MPIType const Type<std::int16_t>::value = MPI_INT16_T;
 MPIType const Type<std::int32_t>::value = MPI_INT32_T;
@@ -33,5 +32,4 @@ static_assert(is_registered_type<std::complex<double>>::value,
               "Checking complex double is registered");
 static_assert(not is_registered_type<std::complex<int>>::value,
               "Checking complex int is NOT registered");
-}  // namespace mpi
-}  // namespace sopt
+} // namespace sopt::mpi

--- a/cpp/sopt/mpi/registered_types.h
+++ b/cpp/sopt/mpi/registered_types.h
@@ -5,8 +5,7 @@
 #ifdef SOPT_MPI
 #include <complex>
 #include <mpi.h>
-namespace sopt {
-namespace mpi {
+namespace sopt::mpi {
 //! Type of an mpi tupe
 typedef decltype(MPI_CHAR) MPIType;
 // Some MPI libraries don't actually have a type defined that will work in the above line
@@ -73,7 +72,6 @@ template <class T, class = details::void_t<>>
 class is_registered_type : public std::false_type {};
 template <class T>
 class is_registered_type<T, details::void_t<decltype(Type<T>::value)>> : public std::true_type {};
-}  // namespace mpi
-}  // namespace sopt
+} // namespace sopt::mpi
 #endif
 #endif /* ifndef SOPT_TYPES */

--- a/cpp/sopt/mpi/session.cc
+++ b/cpp/sopt/mpi/session.cc
@@ -5,8 +5,7 @@
 #include "sopt/logging.h"
 #include "sopt/types.h"
 
-namespace sopt {
-namespace mpi {
+namespace sopt::mpi {
 
 namespace details {
 void initializer::deleter(initializer *tag) {
@@ -80,5 +79,4 @@ void finalize() {
   MPI_Finalize();
 }
 
-}  // namespace mpi
-}  // namespace sopt
+} // namespace sopt::mpi

--- a/cpp/sopt/mpi/session.h
+++ b/cpp/sopt/mpi/session.h
@@ -8,8 +8,7 @@
 #include <mpi.h>
 #endif
 
-namespace sopt {
-namespace mpi {
+namespace sopt::mpi {
 #ifdef SOPT_MPI
 namespace details {
 struct initializer {
@@ -29,6 +28,5 @@ bool finalized();
 inline void init(int argc, const char **argv) {}
 inline bool initialized() { return false; };
 #endif
-}  // namespace mpi
-}  // namespace sopt
+} // namespace sopt::mpi
 #endif /* ifndef SOPT_MPI_SESSION_H */

--- a/cpp/sopt/mpi/utilities.h
+++ b/cpp/sopt/mpi/utilities.h
@@ -8,8 +8,7 @@
 #include "sopt/mpi/communicator.h"
 #include "sopt/real_type.h"
 
-namespace sopt {
-namespace mpi {
+namespace sopt::mpi {
 
 //! Computes norm of distributed vector
 template <class T>
@@ -63,7 +62,6 @@ typename real_type<typename T0::Scalar>::type l1_norm(Eigen::MatrixBase<T0> cons
                                                       Communicator const &comm) {
   return comm.all_sum_all(sopt::l1_norm(input));
 }
-}  // namespace mpi
-}  // namespace sopt
+} // namespace sopt::mpi
 #endif
 #endif

--- a/cpp/sopt/objective_functions.h
+++ b/cpp/sopt/objective_functions.h
@@ -9,8 +9,7 @@
 #include "sopt/maths.h"
 #include "sopt/types.h"
 
-namespace sopt {
-namespace objective_functions {
+namespace sopt::objective_functions {
 //! returns g(x) + ||y - Φ x||_2^2 as a function
 template <class T>
 std::function<t_real(T)> const unconstrained_regularisation(
@@ -31,10 +30,8 @@ std::function<t_real(T)> const unconstrained_l1_regularisation(
     const t_real &gamma, const t_real &sig, const T &y,
     const sopt::LinearTransform<T> &measurement_operator,
     const sopt::LinearTransform<T> &wavelet_operator);
-}  // namespace objective_functions
-}  // namespace sopt
-namespace sopt {
-namespace objective_functions {
+} // namespace sopt::objective_functions
+namespace sopt::objective_functions {
 
 template <class T>
 std::function<t_real(T)> const unconstrained_regularisation(
@@ -70,6 +67,5 @@ std::function<t_real(T)> const unconstrained_l1_regularisation(
   const LinearTransform<T> mop = {measurement_operator, measurement_operator};
   return unconstrained_l1_regularisation<T>(gamma, sig, mop * y, mop, wavelet_operator);
 }
-}  // namespace objective_functions
-}  // namespace sopt
+} // namespace sopt::objective_functions
 #endif

--- a/cpp/sopt/padmm.h
+++ b/cpp/sopt/padmm.h
@@ -9,8 +9,7 @@
 #include "sopt/logging.h"
 #include "sopt/types.h"
 
-namespace sopt {
-namespace algorithm {
+namespace sopt::algorithm {
 
 //! \brief Proximal Alternate Direction method of mutltipliers
 //! \details \f$\min_{x, z} f(x) + h(z)\f$ subject to \f$Φx + z = y\f$. \f$y\f$ is a target vector.
@@ -263,6 +262,5 @@ typename ProximalADMM<SCALAR>::Diagnostic ProximalADMM<SCALAR>::operator()(
   }
   return {niters, converged, std::move(residual)};
 }
-}  // namespace algorithm
-}  // namespace sopt
+} // namespace sopt::algorithm
 #endif

--- a/cpp/sopt/positive_quadrant.h
+++ b/cpp/sopt/positive_quadrant.h
@@ -4,8 +4,7 @@
 #include "sopt/linear_transform.h"
 #include "sopt/types.h"
 
-namespace sopt {
-namespace algorithm {
+namespace sopt::algorithm {
 //! \brief Computes according to given algorithm and then projects it to the positive quadrant
 //! \details C implementation of the reweighted algorithms uses this, even-though the solutions are
 //! already constrained to the positive quadrant.
@@ -57,7 +56,6 @@ template <class ALGORITHM>
 PositiveQuadrant<ALGORITHM> positive_quadrant(ALGORITHM const &algo) {
   return {algo};
 }
-}  // namespace algorithm
-}  // namespace sopt
+} // namespace sopt::algorithm
 
 #endif

--- a/cpp/sopt/power_method.h
+++ b/cpp/sopt/power_method.h
@@ -14,8 +14,7 @@
 #include "sopt/mpi/communicator.h"
 #endif
 
-namespace sopt {
-namespace algorithm {
+namespace sopt::algorithm {
 //! \brief Returns the eigenvalue and eigenvector for eigenvalue of the Linear Transform with
 //! largest magnitude
 template <class T>
@@ -242,6 +241,5 @@ typename PowerMethod<SCALAR>::DiagnosticAndResult PowerMethod<SCALAR>::operator(
   }
   return DiagnosticAndResult{itermax(), converged, previous_magnitude, eigenvector.normalized()};
 }
-}  // namespace algorithm
-}  // namespace sopt
+} // namespace sopt::algorithm
 #endif

--- a/cpp/sopt/primal_dual.h
+++ b/cpp/sopt/primal_dual.h
@@ -14,8 +14,7 @@
 #include "sopt/mpi/utilities.h"
 #endif
 
-namespace sopt {
-namespace algorithm {
+namespace sopt::algorithm {
 
 //! \brief Primal Dual Algorithm
 //! \details \f$\min_{x, z} f(x) + h(z)\f$ subject to \f$Φx + z = y\f$. \f$y\f$ is a target vector.
@@ -358,6 +357,5 @@ typename PrimalDual<SCALAR>::Diagnostic PrimalDual<SCALAR>::operator()(
   }
   return {niters, converged, std::move(residual)};
 }
-}  // namespace algorithm
-}  // namespace sopt
+} // namespace sopt::algorithm
 #endif

--- a/cpp/sopt/proximal.h
+++ b/cpp/sopt/proximal.h
@@ -11,9 +11,8 @@
 #include "sopt/mpi/utilities.h"
 #endif
 
-namespace sopt {
 //! Holds some standard proximals
-namespace proximal {
+namespace sopt::proximal {
 
 //! Proximal of euclidian norm
 class EuclidianNorm {
@@ -363,7 +362,6 @@ template <class FUNCTION, class VECTOR>
 Translation<FUNCTION, VECTOR> translate(FUNCTION const &func, VECTOR const &translation) {
   return Translation<FUNCTION, VECTOR>(func, translation);
 }
-}  // namespace proximal
-}  // namespace sopt
+} // namespace sopt::proximal
 
 #endif

--- a/cpp/sopt/proximal_expression.h
+++ b/cpp/sopt/proximal_expression.h
@@ -6,9 +6,8 @@
 #include <Eigen/Core>
 #include "sopt/maths.h"
 
-namespace sopt {
 //! Holds some standard proximals
-namespace proximal {
+namespace sopt::proximal {
 
 namespace details {
 //! \brief Expression referencing a lazy proximal function call
@@ -85,11 +84,9 @@ using ProximalExpression = details::DelayedProximalFunction<FUNC, Eigen::MatrixB
 //! Eigen expression from proximal enveloppe functions
 template <class FUNC, class T0>
 using EnveloppeExpression = details::DelayedProximalEnveloppeFunction<FUNC, Eigen::MatrixBase<T0>>;
-}  // namespace proximal
-}  // namespace sopt
+} // namespace sopt::proximal
 
-namespace Eigen {
-namespace internal {
+namespace Eigen::internal {
 template <class FUNCTION, class VECTOR>
 struct traits<sopt::proximal::details::DelayedProximalFunction<FUNCTION, VECTOR>> {
   typedef typename VECTOR::PlainObject ReturnType;
@@ -98,7 +95,6 @@ template <class FUNCTION, class VECTOR>
 struct traits<sopt::proximal::details::DelayedProximalEnveloppeFunction<FUNCTION, VECTOR>> {
   typedef typename VECTOR::PlainObject ReturnType;
 };
-}  // namespace internal
-}  // namespace Eigen
+} // namespace Eigen::internal
 
 #endif

--- a/cpp/sopt/reweighted.h
+++ b/cpp/sopt/reweighted.h
@@ -4,8 +4,7 @@
 #include "sopt/linear_transform.h"
 #include "sopt/types.h"
 
-namespace sopt {
-namespace algorithm {
+namespace sopt::algorithm {
 template <class ALGORITHM>
 class Reweighted;
 
@@ -284,6 +283,5 @@ Reweighted<PositiveQuadrant<PrimalDual<SCALAR>>> reweighted(PrimalDual<SCALAR> c
   return {posq, set_weights, reweightee};
 }
 
-}  // namespace algorithm
-}  // namespace sopt
+} // namespace sopt::algorithm
 #endif

--- a/cpp/sopt/sdmm.h
+++ b/cpp/sopt/sdmm.h
@@ -14,8 +14,7 @@
 #include "sopt/types.h"
 #include "sopt/wrapper.h"
 
-namespace sopt {
-namespace algorithm {
+namespace sopt::algorithm {
 
 //! \brief Simultaneous-direction method of the multipliers
 //! \details The algorithm is detailed in (doi) 10.1093/mnras/stu202.
@@ -303,6 +302,5 @@ void SDMM<SCALAR>::sanity_check(t_Vector const &x) const {
   }
   if (doexit) SOPT_THROW("Input to SDMM is inconsistent");
 }
-}  // namespace algorithm
-}  // namespace sopt
+} // namespace sopt::algorithm
 #endif

--- a/cpp/sopt/tf_g_proximal.h
+++ b/cpp/sopt/tf_g_proximal.h
@@ -19,8 +19,7 @@
 #include "cppflow/model.h"
 #include "sopt/cppflow_utils.h"
 
-namespace sopt {
-namespace algorithm {
+namespace sopt::algorithm {
 
 // Implementation of g_proximal with a TensorFlow model. Owns private
 // object model_ and implements the
@@ -105,13 +104,12 @@ protected:
     // Added template keyword to suppress error on apple-clang, for reference
     // https://stackoverflow.com/questions/3786360/confusing-template-error
     auto output_vector = model_output[0].template get_data<float>();
-    
+
     for(int i = 0; i < image_size; i++) {
       image_out[i] = static_cast<Scalar>(output_vector[i]);
     }
   }
 
 };
-}
-}
+} // namespace sopt::algorithm
 #endif

--- a/cpp/sopt/tv_primal_dual.h
+++ b/cpp/sopt/tv_primal_dual.h
@@ -13,8 +13,7 @@
 #include "sopt/relative_variation.h"
 #include "sopt/types.h"
 
-namespace sopt {
-namespace algorithm {
+namespace sopt::algorithm {
 template <class SCALAR>
 class TVPrimalDual {
   //! Underlying algorithm
@@ -391,6 +390,5 @@ bool TVPrimalDual<SCALAR>::is_converged(ScalarRelativeVariation<Scalar> &scalvar
   // better evaluate each convergence function everytime, especially with mpi
   return user and res and obj;
 }
-}  // namespace algorithm
-}  // namespace sopt
+} // namespace sopt::algorithm
 #endif

--- a/cpp/sopt/utilities.cc
+++ b/cpp/sopt/utilities.cc
@@ -34,8 +34,7 @@ uint32_t convert_from_greyscale(double pixel) {
 }
 }  // namespace
 
-namespace sopt {
-namespace utilities {
+namespace sopt::utilities {
 Image<> read_tiff(std::string const &filename) {
   SOPT_MEDIUM_LOG("Reading image file {} ", filename);
   TIFF *tif = TIFFOpen(filename.c_str(), "r");
@@ -99,5 +98,4 @@ void write_tiff(Image<> const &image, std::string const &filename) {
   TIFFClose(tif);
   SOPT_TRACE("Freeing raster");
 }
-}  // namespace utilities
-}  // namespace sopt
+} // namespace sopt::utilities

--- a/cpp/sopt/utilities.h
+++ b/cpp/sopt/utilities.h
@@ -5,12 +5,10 @@
 #include <Eigen/Core>
 #include "sopt/types.h"
 
-namespace sopt {
-namespace utilities {
+namespace sopt::utilities {
 //! Reads tiff image
 sopt::Image<> read_tiff(std::string const &name);
 //! Writes a tiff greyscale file
 void write_tiff(Image<> const &image, std::string const &filename);
-}  // namespace utilities
-}  // namespace sopt
+} // namespace sopt::utilities
 #endif

--- a/cpp/sopt/wavelets/direct.h
+++ b/cpp/sopt/wavelets/direct.h
@@ -7,8 +7,7 @@
 #include "sopt/wavelets/wavelet_data.h"
 
 // Function inside anonymouns namespace won't appear in library
-namespace sopt {
-namespace wavelets {
+namespace sopt::wavelets {
 
 namespace {
 //! \brief Single-level 1d direct transform
@@ -110,6 +109,5 @@ auto direct_transform(Eigen::ArrayBase<T0> const &signal, t_uint levels, Wavelet
   direct_transform(result, signal, levels, wavelet);
   return result;
 }
-}  // namespace wavelets
-}  // namespace sopt
+} // namespace sopt::wavelets
 #endif

--- a/cpp/sopt/wavelets/indirect.h
+++ b/cpp/sopt/wavelets/indirect.h
@@ -7,8 +7,7 @@
 #include "sopt/wavelets/wavelet_data.h"
 
 // Function inside anonymouns namespace won't appear in library
-namespace sopt {
-namespace wavelets {
+namespace sopt::wavelets {
 namespace {
 //! Single-level 1d indirect transform
 //! \param[in] coeffs_: input coefficients
@@ -114,6 +113,5 @@ auto indirect_transform(Eigen::ArrayBase<T0> const &coeffs, t_uint levels,
   indirect_transform(coeffs, result, levels, wavelet);
   return result;
 }
-}  // namespace wavelets
-}  // namespace sopt
+} // namespace sopt::wavelets
 #endif

--- a/cpp/sopt/wavelets/innards.impl.h
+++ b/cpp/sopt/wavelets/innards.impl.h
@@ -5,8 +5,7 @@
 #include <Eigen/Core>
 
 // Function inside anonymouns namespace won't appear in library
-namespace sopt {
-namespace wavelets {
+namespace sopt::wavelets {
 namespace {
 //! \brief Returns evaluated expression or copy of input
 //! \details Gets C++ to figure out what the exact type is. Eigen tries and avoids copies. But
@@ -138,6 +137,5 @@ void up_convolve_sum(Eigen::ArrayBase<T0> &result, Eigen::ArrayBase<T1> const &c
   }
 }
 }  // namespace
-}  // namespace wavelets
-}  // namespace sopt
+} // namespace sopt::wavelets
 #endif

--- a/cpp/sopt/wavelets/sara.cc
+++ b/cpp/sopt/wavelets/sara.cc
@@ -1,6 +1,4 @@
 #include "sara.h"
 #include "sopt/config.h"
 
-namespace sopt {
-namespace wavelets {}  // namespace wavelets
-}  // namespace sopt
+namespace sopt::wavelets {}  // namespace sopt::wavelets

--- a/cpp/sopt/wavelets/sara.h
+++ b/cpp/sopt/wavelets/sara.h
@@ -12,8 +12,7 @@
 #include "sopt/mpi/communicator.h"
 #endif
 
-namespace sopt {
-namespace wavelets {
+namespace sopt::wavelets {
 
 //! Sparsity Averaging Reweighted Analysis
 class SARA : public std::vector<Wavelet> {
@@ -210,6 +209,5 @@ T distribute_sara(T const &all_wavelets, mpi::Communicator const &comm) {
   return distribute_sara<T>(all_wavelets, comm.size(), comm.rank());
 }
 #endif
-}  // namespace wavelets
-}  // namespace sopt
+} // namespace sopt::wavelets
 #endif

--- a/cpp/sopt/wavelets/wavelet_data.cc
+++ b/cpp/sopt/wavelets/wavelet_data.cc
@@ -4,8 +4,7 @@
 #include <Eigen/Core>
 #include "sopt/types.h"
 
-namespace sopt {
-namespace wavelets {
+namespace sopt::wavelets {
 
 namespace {
 //! Vector setup from initializer list, because easier
@@ -1718,5 +1717,4 @@ WaveletData const &daubechies_data(t_uint n) {
   }
   return *result;
 }
-}  // namespace wavelets
-}  // namespace sopt
+} // namespace sopt::wavelets

--- a/cpp/sopt/wavelets/wavelet_data.h
+++ b/cpp/sopt/wavelets/wavelet_data.h
@@ -5,8 +5,7 @@
 #include "sopt/types.h"
 #include "sopt/wavelets/innards.impl.h"
 
-namespace sopt {
-namespace wavelets {
+namespace sopt::wavelets {
 
 //! Holds wavelets coefficients
 struct WaveletData {
@@ -42,6 +41,5 @@ struct WaveletData {
 
 //! Factory function returning specific daubechie wavelet data
 WaveletData const &daubechies_data(t_uint);
-}  // namespace wavelets
-}  // namespace sopt
+} // namespace sopt::wavelets
 #endif

--- a/cpp/sopt/wavelets/wavelets.cc
+++ b/cpp/sopt/wavelets/wavelets.cc
@@ -3,8 +3,7 @@
 #include <exception>
 #include "sopt/logging.h"
 
-namespace sopt {
-namespace wavelets {
+namespace sopt::wavelets {
 
 Wavelet factory(std::string name, t_uint nlevels) {
   if (name == "dirac" or name == "Dirac") {
@@ -22,5 +21,4 @@ Wavelet factory(std::string name, t_uint nlevels) {
   // Unknown input wavelet
   throw std::exception();
 }
-}  // namespace wavelets
-}  // namespace sopt
+} // namespace sopt::wavelets

--- a/cpp/sopt/wavelets/wavelets.h
+++ b/cpp/sopt/wavelets/wavelets.h
@@ -7,8 +7,7 @@
 #include "sopt/wavelets/indirect.h"
 #include "sopt/wavelets/wavelet_data.h"
 
-namespace sopt {
-namespace wavelets {
+namespace sopt::wavelets {
 
 // Advance declaration so we can define the subsequent friend function
 class Wavelet;
@@ -133,6 +132,5 @@ class Wavelet : public WaveletData {
   //! Number of levels in the wavelet
   t_uint levels_;
 };
-}  // namespace wavelets
-}  // namespace sopt
+} // namespace sopt::wavelets
 #endif

--- a/cpp/sopt/wrapper.h
+++ b/cpp/sopt/wrapper.h
@@ -9,8 +9,7 @@
 #include "sopt/maths.h"
 #include "sopt/types.h"
 
-namespace sopt {
-namespace details {
+namespace sopt::details {
 //! Expression referencing the result of a function call
 template <class FUNCTION, class DERIVED>
 class AppliedFunction : public Eigen::ReturnByValue<AppliedFunction<FUNCTION, DERIVED>> {
@@ -132,15 +131,12 @@ WrapFunction<VECTOR> wrap(OperatorFunction<VECTOR> const &func,
                           std::array<t_int, 3> sizes = {{1, 1, 0}}) {
   return WrapFunction<VECTOR>(func, sizes);
 }
-}  // namespace details
-}  // namespace sopt
+} // namespace sopt::details
 
-namespace Eigen {
-namespace internal {
+namespace Eigen::internal {
 template <class FUNCTION, class VECTOR>
 struct traits<sopt::details::AppliedFunction<FUNCTION, VECTOR>> {
   typedef typename VECTOR::PlainObject ReturnType;
 };
-}  // namespace internal
-}  // namespace Eigen
+} // namespace Eigen::internal
 #endif

--- a/cpp/tools_for_tests/directories.in.h
+++ b/cpp/tools_for_tests/directories.in.h
@@ -4,14 +4,12 @@
 #include "sopt/config.h"
 #include <string>
 
-namespace sopt {
-namespace notinstalled {
+namespace sopt::notinstalled {
 //! Holds images and such
 inline std::string data_directory() { return "@PROJECT_SOURCE_DIR@/images"; }
 //! Output artefacts from tests
 inline std::string output_directory() { return "@PROJECT_BINARY_DIR@/outputs"; }
 //! Tensorflow models
 inline std::string models_directory() { return "@PROJECT_SOURCE_DIR@/lexci_models"; }
-}
-} /* sopt::notinstalled */
+} // namespace sopt::notinstalled
 #endif

--- a/cpp/tools_for_tests/tiffwrappers.cc
+++ b/cpp/tools_for_tests/tiffwrappers.cc
@@ -5,12 +5,10 @@
 #include "sopt/types.h"
 #include "sopt/utilities.h"
 
-namespace sopt {
-namespace notinstalled {
+namespace sopt::notinstalled {
 Image<> read_standard_tiff(std::string const &name) {
   std::string const stdname = sopt::notinstalled::data_directory() + "/" + name + ".tiff";
   bool const is_std = std::ifstream(stdname).good();
   return sopt::utilities::read_tiff(is_std ? stdname : name);
 }
-}  // namespace notinstalled
-}  // namespace sopt
+} // namespace sopt::notinstalled

--- a/cpp/tools_for_tests/tiffwrappers.h
+++ b/cpp/tools_for_tests/tiffwrappers.h
@@ -5,10 +5,8 @@
 #include <Eigen/Core>
 #include "sopt/types.h"
 
-namespace sopt {
-namespace notinstalled {
+namespace sopt::notinstalled {
 //! Reads tiff image from sopt data directory if it exists
 sopt::Image<> read_standard_tiff(std::string const &name);
-}  // namespace notinstalled
-}  // namespace sopt
+} // namespace sopt::notinstalled
 #endif


### PR DESCRIPTION
C++17 introduced the ability to use concatenated nested namespaces instead of hierarchical nesting of namespace blocks. This is what C++20 & beyond standards uses right within the standard library.

#### References:
- https://stackoverflow.com/a/28022457
- https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n4230.html
- https://www.youtube.com/watch?v=-CTPds55l2U
- https://rules.sonarsource.com/cpp/RSPEC-5812

Closes #370.