### PR TITLE
Replace typedefs with using aliases

### DIFF
--- a/cpp/benchmarks/conjugate_gradient.cc
+++ b/cpp/benchmarks/conjugate_gradient.cc
@@ -26,7 +26,7 @@ void function_cg(benchmark::State &state) {
 
   auto const AhA = A.matrix().transpose().conjugate() * A.matrix();
   auto const Ahb = A.matrix().transpose().conjugate() * b.matrix();
-  typedef sopt::Vector<TYPE> t_Vector;
+  using t_Vector = sopt::Vector<TYPE>;
   auto func = [&AhA](t_Vector &out, t_Vector const &input) { out = AhA * input; };
   auto output = sopt::Vector<TYPE>::Zero(N).eval();
   sopt::ConjugateGradient cg(0, epsilon);

--- a/cpp/benchmarks/l1_proximal.cc
+++ b/cpp/benchmarks/l1_proximal.cc
@@ -6,7 +6,7 @@
 
 template <class TYPE>
 void function_l1p(benchmark::State &state) {
-  typedef typename sopt::real_type<TYPE>::type Real;
+  using Real = typename sopt::real_type<TYPE>::type;
   auto const N = state.range_x();
   auto const input = sopt::Vector<TYPE>::Random(N).eval();
   auto const Psi = sopt::Matrix<TYPE>::Random(input.size(), input.size() * 10).eval();

--- a/cpp/docs/Doxyfile.in
+++ b/cpp/docs/Doxyfile.in
@@ -391,7 +391,7 @@ SUBGROUPING            = YES
 INLINE_GROUPED_CLASSES = NO
 
 # When the INLINE_SIMPLE_STRUCTS tag is set to YES, structs, classes, and unions
-# with only public data fields or simple typedef fields will be shown inline in
+# with only public data fields or simple type alias fields will be shown inline in
 # the documentation of the scope in which they are defined (i.e. file,
 # namespace, or group documentation), provided this scope is documented. If set
 # to NO, structs, classes, and unions are shown on a separate page (for HTML and
@@ -400,16 +400,16 @@ INLINE_GROUPED_CLASSES = NO
 
 INLINE_SIMPLE_STRUCTS  = NO
 
-# When TYPEDEF_HIDES_STRUCT tag is enabled, a typedef of a struct, union, or
-# enum is documented as struct, union, or enum with the name of the typedef. So
-# typedef struct TypeS {} TypeT, will appear in the documentation as a struct
-# with name TypeT. When disabled the typedef will appear as a member of a file,
+# When TYPEALIAS_HIDES_STRUCT tag is enabled, a type alias of a struct, union, or
+# enum is documented as struct, union, or enum with the name of the type alias. So
+# using TypeT = struct TypeS {}; will appear in the documentation as a struct
+# with name TypeT. When disabled the type alias will appear as a member of a file,
 # namespace, or class. And the struct will be named TypeS. This can typically be
 # useful for C code in case the coding convention dictates that all compound
-# types are typedef'ed and only the typedef is referenced, never the tag name.
+# types are type aliases and only the alias is referenced, never the tag name.
 # The default value is: NO.
 
-TYPEDEF_HIDES_STRUCT   = NO
+TYPEALIAS_HIDES_STRUCT   = NO
 
 # The size of the symbol lookup cache can be set using LOOKUP_CACHE_SIZE. This
 # cache is used to resolve symbols given their name and scope. Since this can be
@@ -874,7 +874,7 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = 
+EXCLUDE                =
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded

--- a/cpp/examples/conjugate_gradient.cc
+++ b/cpp/examples/conjugate_gradient.cc
@@ -8,8 +8,8 @@ int main(int, char const **) {
   // Lets try both approaches.
 
   // Creates the input.
-  typedef sopt::Vector<sopt::t_complex> t_Vector;
-  typedef sopt::Matrix<sopt::t_complex> t_Matrix;
+  using t_Vector = sopt::Vector<sopt::t_complex>;
+  using t_Matrix = sopt::Matrix<sopt::t_complex>;
   t_Vector const b = t_Vector::Random(8);
   t_Matrix const A = t_Matrix::Random(b.size(), b.size());
 

--- a/cpp/examples/forward_backward/inpainting.cc
+++ b/cpp/examples/forward_backward/inpainting.cc
@@ -22,17 +22,17 @@
 
 // \min_{x} ||\Psi^Tx||_1 \quad \mbox{s.t.} \quad ||y - Ax||_2 < \epsilon and x \geq 0
 int main(int argc, char const **argv) {
-  // Some typedefs for simplicity
-  typedef double Scalar;
+  // Some type aliases for simplicity
+  using Scalar = double;
   // Column vector - linear algebra - A * x is a matrix-vector multiplication
   // type expected by Forward Backward
-  typedef sopt::Vector<Scalar> Vector;
+  using Vector = sopt::Vector<Scalar>;
   // Matrix - linear algebra - A * x is a matrix-vector multiplication
   // type expected by Forward Backward
-  typedef sopt::Matrix<Scalar> Matrix;
+  using Matrix = sopt::Matrix<Scalar>;
   // Image - 2D array - A * x is a coefficient-wise multiplication
   // Type expected by wavelets and image write/read functions
-  typedef sopt::Image<Scalar> Image;
+  using Image = sopt::Image<Scalar>;
 
   std::string const input = argc >= 2 ? argv[1] : "cameraman256";
   std::string const output = argc == 3 ? argv[2] : "none";

--- a/cpp/examples/forward_backward/inpainting_credible_interval.cc
+++ b/cpp/examples/forward_backward/inpainting_credible_interval.cc
@@ -23,17 +23,17 @@
 
 // \min_{x} ||\Psi^Tx||_1 \quad \mbox{s.t.} \quad ||y - Ax||_2 < \epsilon and x \geq 0
 int main(int argc, char const **argv) {
-  // Some typedefs for simplicity
-  typedef sopt::t_real Scalar;
+  // Some type aliases for simplicity
+  using Scalar = sopt::t_real;
   // Column vector - linear algebra - A * x is a matrix-vector multiplication
   // type expected by Forward Backward
-  typedef sopt::Vector<Scalar> Vector;
+  using Vector = sopt::Vector<Scalar>;
   // Matrix - linear algebra - A * x is a matrix-vector multiplication
   // type expected by Forward Backward
-  typedef sopt::Matrix<Scalar> Matrix;
+  using Matrix = sopt::Matrix<Scalar>;
   // Image - 2D array - A * x is a coefficient-wise multiplication
   // Type expected by wavelets and image write/read functions
-  typedef sopt::Image<Scalar> Image;
+  using Image = sopt::Image<Scalar>;
 
   std::string const input = argc >= 2 ? argv[1] : "cameraman256";
   std::string const output = argc == 3 ? argv[2] : "none";

--- a/cpp/examples/forward_backward/inpainting_joint_map.cc
+++ b/cpp/examples/forward_backward/inpainting_joint_map.cc
@@ -23,17 +23,17 @@
 
 // \min_{x} ||\Psi^Tx||_1 \quad \mbox{s.t.} \quad ||y - Ax||_2 < \epsilon and x \geq 0
 int main(int argc, char const **argv) {
-  // Some typedefs for simplicity
-  typedef double Scalar;
+  // Some type aliases for simplicity
+  using Scalar = double;
   // Column vector - linear algebra - A * x is a matrix-vector multiplication
   // type expected by Forward Backward
-  typedef sopt::Vector<Scalar> Vector;
+  using Vector = sopt::Vector<Scalar>;
   // Matrix - linear algebra - A * x is a matrix-vector multiplication
   // type expected by Forward Backward
-  typedef sopt::Matrix<Scalar> Matrix;
+  using Matrix = sopt::Matrix<Scalar>;
   // Image - 2D array - A * x is a coefficient-wise multiplication
   // Type expected by wavelets and image write/read functions
-  typedef sopt::Image<Scalar> Image;
+  using Image = sopt::Image<Scalar>;
 
   std::string const input = argc >= 2 ? argv[1] : "cameraman256";
   std::string const output = argc == 3 ? argv[2] : "none";

--- a/cpp/examples/forward_backward/l2_inpainting.cc
+++ b/cpp/examples/forward_backward/l2_inpainting.cc
@@ -20,17 +20,17 @@
 
 // \min_{x} ||\Psi^Tx||_1 \quad \mbox{s.t.} \quad ||y - Ax||_2 < \epsilon and x \geq 0
 int main(int argc, char const **argv) {
-  // Some typedefs for simplicity
-  typedef double Scalar;
+  // Some type aliases for simplicity
+  using Scalar = double;
   // Column vector - linear algebra - A * x is a matrix-vector multiplication
   // type expected by Forward Backward
-  typedef sopt::Vector<Scalar> Vector;
+  using Vector = sopt::Vector<Scalar>;
   // Matrix - linear algebra - A * x is a matrix-vector multiplication
   // type expected by Forward Backward
-  typedef sopt::Matrix<Scalar> Matrix;
+  using Matrix = sopt::Matrix<Scalar>;
   // Image - 2D array - A * x is a coefficient-wise multiplication
   // Type expected by wavelets and image write/read functions
-  typedef sopt::Image<Scalar> Image;
+  using Image = sopt::Image<Scalar>;
 
   std::string const input = argc >= 2 ? argv[1] : "cameraman256";
   std::string const output = argc == 3 ? argv[2] : "none";

--- a/cpp/examples/l1_proximal.cc
+++ b/cpp/examples/l1_proximal.cc
@@ -5,8 +5,8 @@
 int main(int, char const **) {
   sopt::logging::initialize();
 
-  typedef sopt::t_complex Scalar;
-  typedef sopt::real_type<Scalar>::type Real;
+  using Scalar = sopt::t_complex;
+  using Real = sopt::real_type<Scalar>::type;
   auto const input = sopt::Vector<Scalar>::Random(10).eval();
   auto const Psi = sopt::Matrix<Scalar>::Random(input.size(), input.size() * 10).eval();
   sopt::Vector<Real> const weights =

--- a/cpp/examples/positive_quadrant_projection.cc
+++ b/cpp/examples/positive_quadrant_projection.cc
@@ -3,7 +3,7 @@
 
 int main(int, char const **) {
   // Create a matrix with a single negative real numbers
-  typedef sopt::Image<std::complex<int>> t_Matrix;
+  using t_Matrix = sopt::Image<std::complex<int>>;
   t_Matrix input = 2 * t_Matrix::Ones(5, 5) + t_Matrix::Random(5, 5);
 
   // Apply projection

--- a/cpp/examples/power_method.cc
+++ b/cpp/examples/power_method.cc
@@ -3,7 +3,7 @@
 #include "sopt/power_method.h"
 
 int main(int, char const **) {
-  typedef sopt::t_real Scalar;
+  using Scalar = sopt::t_real;
   auto const N = 10;
 
   // Create some kind of matrix

--- a/cpp/examples/primal_dual/inpainting.cc
+++ b/cpp/examples/primal_dual/inpainting.cc
@@ -28,19 +28,19 @@
 
 // \min_{x} ||\Psi^Tx||_1 \quad \mbox{s.t.} \quad ||y - Ax||_2 < \epsilon and x \geq 0
 int main(int argc, char const **argv) {
-  // Some typedefs for simplicity
-  typedef double Scalar;
+  // Some type aliases for simplicity
+  using Scalar = double;
   // Column vector - linear algebra - A * x is a matrix-vector multiplication
   // type expected by PrimalDual
-  typedef sopt::Vector<Scalar> Vector;
+  using Vector = sopt::Vector<Scalar>;
 
-  //  typedef sopt::Vector<sopt::t_complex> Complex;
+  //  using Complex = sopt::Vector<sopt::t_complex>;
   // Matrix - linear algebra - A * x is a matrix-vector multiplication
   // type expected by PrimalDual
-  typedef sopt::Matrix<Scalar> Matrix;
+  using Matrix = sopt::Matrix<Scalar>;
   // Image - 2D array - A * x is a coefficient-wise multiplication
   // Type expected by wavelets and image write/read functions
-  typedef sopt::Image<Scalar> Image;
+  using Image = sopt::Image<Scalar>;
 
   std::string const input = argc >= 2 ? argv[1] : "cameraman256";
   std::string const output = argc == 3 ? argv[2] : "none";

--- a/cpp/examples/primal_dual/tv_inpainting.cc
+++ b/cpp/examples/primal_dual/tv_inpainting.cc
@@ -26,19 +26,19 @@
 
 // \min_{x} ||\Psi^Tx||_1 \quad \mbox{s.t.} \quad ||y - Ax||_2 < \epsilon and x \geq 0
 int main(int argc, char const **argv) {
-  // Some typedefs for simplicity
-  typedef double Scalar;
+  // Some type aliases for simplicity
+  using Scalar = double;
   // Column vector - linear algebra - A * x is a matrix-vector multiplication
   // type expected by PrimalDual
-  typedef sopt::Vector<Scalar> Vector;
+  using Vector = sopt::Vector<Scalar>;
 
-  //  typedef sopt::Vector<sopt::t_complex> Complex;
+  //  using Complex = sopt::Vector<sopt::t_complex>;
   // Matrix - linear algebra - A * x is a matrix-vector multiplication
   // type expected by PrimalDual
-  typedef sopt::Matrix<Scalar> Matrix;
+  using Matrix = sopt::Matrix<Scalar>;
   // Image - 2D array - A * x is a coefficient-wise multiplication
   // Type expected by wavelets and image write/read functions
-  typedef sopt::Image<Scalar> Image;
+  using Image = sopt::Image<Scalar>;
 
   std::string const input = argc >= 2 ? argv[1] : "cameraman256";
   std::string const output = argc == 3 ? argv[2] : "none";

--- a/cpp/examples/proximal_admm/euclidian_norm.cc
+++ b/cpp/examples/proximal_admm/euclidian_norm.cc
@@ -10,10 +10,10 @@ int main(int, char const **) {
   // See set_level function for levels.
   sopt::logging::initialize();
 
-  // Some typedefs for simplicity
-  typedef sopt::t_real t_Scalar;
-  typedef sopt::Vector<t_Scalar> t_Vector;
-  typedef sopt::Matrix<t_Scalar> t_Matrix;
+  // Some type aliases for simplicity
+  using t_Scalar = sopt::t_real;
+  using t_Vector = sopt::Vector<t_Scalar>;
+  using t_Matrix = sopt::Matrix<t_Scalar>;
 
   // Creates the target vectors
   auto const N = 5;

--- a/cpp/examples/proximal_admm/inpainting.cc
+++ b/cpp/examples/proximal_admm/inpainting.cc
@@ -21,17 +21,17 @@
 
 // \min_{x} ||\Psi^Tx||_1 \quad \mbox{s.t.} \quad ||y - Ax||_2 < \epsilon and x \geq 0
 int main(int argc, char const **argv) {
-  // Some typedefs for simplicity
-  typedef double Scalar;
+  // Some type aliases for simplicity
+  using Scalar = double;
   // Column vector - linear algebra - A * x is a matrix-vector multiplication
   // type expected by ProximalADMM
-  typedef sopt::Vector<Scalar> Vector;
+  using Vector = sopt::Vector<Scalar>;
   // Matrix - linear algebra - A * x is a matrix-vector multiplication
   // type expected by ProximalADMM
-  typedef sopt::Matrix<Scalar> Matrix;
+  using Matrix = sopt::Matrix<Scalar>;
   // Image - 2D array - A * x is a coefficient-wise multiplication
   // Type expected by wavelets and image write/read functions
-  typedef sopt::Image<Scalar> Image;
+  using Image = sopt::Image<Scalar>;
 
   std::string const input = argc >= 2 ? argv[1] : "cameraman256";
   std::string const output = argc == 3 ? argv[2] : "none";

--- a/cpp/examples/proximal_admm/reweighted.cc
+++ b/cpp/examples/proximal_admm/reweighted.cc
@@ -24,17 +24,17 @@
 
 // \min_{x} ||\Psi^Tx||_1 \quad \mbox{s.t.} \quad ||y - Ax||_2 < \epsilon and x \geq 0
 int main(int argc, char const **argv) {
-  // Some typedefs for simplicity
-  typedef double Scalar;
+  // Some type aliases for simplicity
+  using Scalar = double;
   // Column vector - linear algebra - A * x is a matrix-vector multiplication
   // type expected by ProximalADMM
-  typedef sopt::Vector<Scalar> Vector;
+  using Vector = sopt::Vector<Scalar>;
   // Matrix - linear algebra - A * x is a matrix-vector multiplication
   // type expected by ProximalADMM
-  typedef sopt::Matrix<Scalar> Matrix;
+  using Matrix = sopt::Matrix<Scalar>;
   // Image - 2D array - A * x is a coefficient-wise multiplication
   // Type expected by wavelets and image write/read functions
-  typedef sopt::Image<Scalar> Image;
+  using Image = sopt::Image<Scalar>;
 
   std::string const input = argc >= 2 ? argv[1] : "cameraman256";
   std::string const output = argc == 3 ? argv[2] : "none";

--- a/cpp/examples/sara.cc
+++ b/cpp/examples/sara.cc
@@ -2,7 +2,7 @@
 
 int main(int, char const **) {
   // Creates SARA with two wavelets
-  typedef std::tuple<std::string, sopt::t_uint> t_i;
+  using t_i = std::tuple<std::string, sopt::t_uint>;
   sopt::wavelets::SARA sara{t_i{"DB4", 5}, t_i{"DB8", 2}};
 
   // Then another one for good measure

--- a/cpp/examples/sdmm/euclidian_norm.cc
+++ b/cpp/examples/sdmm/euclidian_norm.cc
@@ -8,10 +8,10 @@ int main(int, char const **) {
   // See set_level function for levels.
   sopt::logging::initialize();
 
-  // Some typedefs for simplicity
-  typedef sopt::t_complex t_Scalar;
-  typedef sopt::Vector<t_Scalar> t_Vector;
-  typedef sopt::Matrix<t_Scalar> t_Matrix;
+  // Some type aliases for simplicity
+  using t_Scalar = sopt::t_complex;
+  using t_Vector = sopt::Vector<t_Scalar>;
+  using t_Matrix = sopt::Matrix<t_Scalar>;
 
   // Creates the transformation matrices
   auto const N = 10;

--- a/cpp/examples/sdmm/inpainting.cc
+++ b/cpp/examples/sdmm/inpainting.cc
@@ -21,17 +21,17 @@
 
 // \min_{x} ||\Psi^Tx||_1 \quad \mbox{s.t.} \quad ||y - Ax||_2 < \epsilon and x \geq 0
 int main(int argc, char const **argv) {
-  // Some typedefs for simplicity
-  typedef double Scalar;
+  // Some type aliases for simplicity
+  using Scalar = double;
   // Column vector - linear algebra - A * x is a matrix-vector multiplication
   // type expected by SDMM
-  typedef sopt::Vector<Scalar> Vector;
+  using Vector = sopt::Vector<Scalar>;
   // Matrix - linear algebra - A * x is a matrix-vector multiplication
   // type expected by SDMM
-  typedef sopt::Matrix<Scalar> Matrix;
+  using Matrix = sopt::Matrix<Scalar>;
   // Image - 2D array - A * x is a coefficient-wise multiplication
   // Type expected by wavelets and image write/read functions
-  typedef sopt::Image<Scalar> Image;
+  using Image = sopt::Image<Scalar>;
 
   std::string const input = argc >= 2 ? argv[1] : "cameraman256";
   std::string const output = argc == 3 ? argv[2] : "none";

--- a/cpp/examples/sdmm/reweighted.cc
+++ b/cpp/examples/sdmm/reweighted.cc
@@ -25,17 +25,17 @@
 // with W_j = ||\Psi^Tx_{j-1}||_1
 // By iterating this algorithm, we can approximate L0 from L1.
 int main(int argc, char const **argv) {
-  // Some typedefs for simplicity
-  typedef double Scalar;
+  // Some type aliases for simplicity
+  using Scalar = double;
   // Column vector - linear algebra - A * x is a matrix-vector multiplication
   // type expected by SDMM
-  typedef sopt::Vector<Scalar> Vector;
+  using Vector = sopt::Vector<Scalar>;
   // Matrix - linear algebra - A * x is a matrix-vector multiplication
   // type expected by SDMM
-  typedef sopt::Matrix<Scalar> Matrix;
+  using Matrix = sopt::Matrix<Scalar>;
   // Image - 2D array - A * x is a coefficient-wise multiplication
   // Type expected by wavelets and image write/read functions
-  typedef sopt::Image<Scalar> Image;
+  using Image = sopt::Image<Scalar>;
 
   std::string const input = argc >= 2 ? argv[1] : "cameraman256";
   std::string const output = argc == 3 ? argv[2] : "none";
@@ -114,7 +114,7 @@ int main(int argc, char const **argv) {
   // positive_quadrant projects the result of SDMM on the positive quadrant.
   // This follows the reweighted algorithm in the original C implementation.
   auto const posq = positive_quadrant(sdmm);
-  typedef std::remove_const<decltype(posq)>::type t_PosQuadSDMM;
+  using t_PosQuadSDMM = std::remove_const<decltype(posq)>::type;
   auto const min_delta = sigma * std::sqrt(y.size()) / std::sqrt(8 * image.size());
   // Sets weight after each sdmm iteration.
   // In practice, this means replacing the proximal of the l1 objective function.

--- a/cpp/sopt/conjugate_gradient.h
+++ b/cpp/sopt/conjugate_gradient.h
@@ -107,8 +107,8 @@ class ConjugateGradient {
 template <class VECTOR, class T1, class MATRIXLIKE>
 ConjugateGradient::Diagnostic ConjugateGradient::implementation(
     VECTOR &x, MATRIXLIKE const &A, Eigen::MatrixBase<T1> const &b) const {
-  typedef typename T1::Scalar Scalar;
-  typedef typename real_type<Scalar>::type Real;
+  using Scalar = typename T1::Scalar;
+  using Real = typename real_type<Scalar>::type;
 
   x.resize(b.size());
   if (std::abs((b.transpose().conjugate() * b)(0)) < tolerance()) {

--- a/cpp/sopt/credible_region.h
+++ b/cpp/sopt/credible_region.h
@@ -80,7 +80,7 @@ std::tuple<t_real, t_real, t_real> find_credible_interval(
     const std::tuple<t_uint, t_uint, t_uint, t_uint> &region,
     const std::function<t_real(typename T::PlainObject)> &objective_function,
     const t_real &energy_upperbound) {
-  typedef typename T::PlainObject Derived;
+  using Derived = typename T::PlainObject;
   assert(energy_upperbound > 0);
   if (solution.size() != cols * rows) SOPT_THROW("Solution is wrong size for credible interval.");
   if ((std::get<2>(region) > rows) or (std::get<3>(region) > cols))
@@ -136,7 +136,7 @@ credible_interval_grid(const Eigen::MatrixBase<T> &solution, const t_uint &rows,
                        const t_real &energy_upperbound) {
   if ((std::get<0>(grid_pixel_size) > rows) or (std::get<1>(grid_pixel_size) > cols))
     SOPT_THROW("Grid pixel size too big.");
-  typedef typename T::PlainObject Derived;
+  using Derived = typename T::PlainObject;
   const t_uint drow = std::get<0>(grid_pixel_size);
   const t_uint dcol = std::get<1>(grid_pixel_size);
   const t_uint grid_rows = std::floor(static_cast<t_real>(rows) / drow);

--- a/cpp/sopt/forward_backward.h
+++ b/cpp/sopt/forward_backward.h
@@ -18,21 +18,21 @@ template <class SCALAR>
 class ForwardBackward {
  public:
   //! Scalar type
-  typedef SCALAR value_type;
+  using value_type = SCALAR;
   //! Scalar type
-  typedef value_type Scalar;
+  using Scalar = value_type;
   //! Real type
-  typedef typename real_type<Scalar>::type Real;
+  using Real = typename real_type<Scalar>::type;
   //! Type of then underlying vectors
-  typedef Vector<Scalar> t_Vector;
+  using t_Vector = Vector<Scalar>;
   //! Type of the Ψ and Ψ^H operations, as well as Φ and Φ^H
-  typedef LinearTransform<t_Vector> t_LinearTransform;
+  using t_LinearTransform = LinearTransform<t_Vector>;
   //! Type of the convergence function
-  typedef std::function<bool(t_Vector const &, t_Vector const &)> t_IsConverged;
+  using t_IsConverged = std::function<bool(const t_Vector &, const t_Vector &)>;
   //! Type of the proximal operator
-  typedef ProximalFunction<Scalar> t_Proximal;
+  using t_Proximal = ProximalFunction<Scalar>;
   //! Type of the gradient
-  typedef typename std::function<void(t_Vector &, const t_Vector &)> t_Gradient;
+  using t_Gradient = typename std::function<void(t_Vector &, const t_Vector &)>;
 
   //! Values indicating how the algorithm ran
   struct Diagnostic {

--- a/cpp/sopt/g_proximal.h
+++ b/cpp/sopt/g_proximal.h
@@ -9,11 +9,11 @@
 // Abstract base class providing the interface to the g_proximal function
 template <class SCALAR> class GProximal {
 
-  typedef sopt::algorithm::ForwardBackward<SCALAR> FB;
-  typedef typename FB::Real Real;
-  typedef typename FB::t_Vector t_Vector;
-  typedef typename FB::t_Proximal t_Proximal;
-  typedef typename FB::t_LinearTransform t_LinearTransform;
+  using FB = sopt::algorithm::ForwardBackward<SCALAR>;
+  using Real = typename FB::Real;
+  using t_Vector = typename FB::t_Vector;
+  using t_Proximal = typename FB::t_Proximal;
+  using t_LinearTransform = typename FB::t_LinearTransform;
   
 public:
 

--- a/cpp/sopt/imaging_forward_backward.h
+++ b/cpp/sopt/imaging_forward_backward.h
@@ -24,17 +24,17 @@ namespace algorithm {
 template <class SCALAR>
 class ImagingForwardBackward {
   //! Underlying algorithm
-  typedef ForwardBackward<SCALAR> FB;
+  using FB = ForwardBackward<SCALAR>;
 
  public:
-  typedef typename FB::value_type value_type;
-  typedef typename FB::Scalar Scalar;
-  typedef typename FB::Real Real;
-  typedef typename FB::t_Vector t_Vector;
-  typedef typename FB::t_LinearTransform t_LinearTransform;
-  typedef typename FB::t_Proximal t_Proximal;
-  typedef typename FB::t_Gradient t_Gradient;
-  typedef typename FB::t_IsConverged t_IsConverged;
+  using value_type = typename FB::value_type;
+  using Scalar = typename FB::Scalar;
+  using Real = typename FB::Real;
+  using t_Vector = typename FB::t_Vector;
+  using t_LinearTransform = typename FB::t_LinearTransform;
+  using t_Proximal = typename FB::t_Proximal;
+  using t_Gradient = typename FB::t_Gradient;
+  using t_IsConverged = typename FB::t_IsConverged;
 
   //! Values indicating how the algorithm ran
   struct Diagnostic : public FB::Diagnostic {

--- a/cpp/sopt/imaging_padmm.h
+++ b/cpp/sopt/imaging_padmm.h
@@ -19,16 +19,16 @@ namespace algorithm {
 template <class SCALAR>
 class ImagingProximalADMM {
   //! Underlying algorithm
-  typedef ProximalADMM<SCALAR> PADMM;
+  using PADMM = ProximalADMM<SCALAR>;
 
  public:
-  typedef typename PADMM::value_type value_type;
-  typedef typename PADMM::Scalar Scalar;
-  typedef typename PADMM::Real Real;
-  typedef typename PADMM::t_Vector t_Vector;
-  typedef typename PADMM::t_LinearTransform t_LinearTransform;
-  typedef typename PADMM::t_Proximal t_Proximal;
-  typedef typename PADMM::t_IsConverged t_IsConverged;
+  using value_type = typename PADMM::value_type;
+  using Scalar = typename PADMM::Scalar;
+  using Real = typename PADMM::Real;
+  using t_Vector = typename PADMM::t_Vector;
+  using t_LinearTransform = typename PADMM::t_LinearTransform;
+  using t_Proximal = typename PADMM::t_Proximal;
+  using t_IsConverged = typename PADMM::t_IsConverged;
 
   //! Values indicating how the algorithm ran
   struct Diagnostic : public PADMM::Diagnostic {

--- a/cpp/sopt/imaging_primal_dual.h
+++ b/cpp/sopt/imaging_primal_dual.h
@@ -19,19 +19,19 @@ namespace algorithm {
 template <class SCALAR>
 class ImagingPrimalDual {
   //! Underlying algorithm
-  typedef PrimalDual<SCALAR> PD;
+  using PD = PrimalDual<SCALAR>;
 
  public:
-  typedef typename PD::value_type value_type;
-  typedef typename PD::Scalar Scalar;
-  typedef typename PD::Real Real;
-  typedef typename PD::t_Vector t_Vector;
-  typedef typename PD::t_LinearTransform t_LinearTransform;
+  using value_type = typename PD::value_type;
+  using Scalar = typename PD::Scalar;
+  using Real = typename PD::Real;
+  using t_Vector = typename PD::t_Vector;
+  using t_LinearTransform = typename PD::t_LinearTransform;
   template <class T>
   using t_Proximal = std::function<void(t_Vector &, const T &, const t_Vector &)>;
-  typedef typename PD::t_IsConverged t_IsConverged;
-  typedef typename PD::t_Constraint t_Constraint;
-  typedef typename PD::t_Random_Updater t_Random_Updater;
+  using t_IsConverged = typename PD::t_IsConverged;
+  using t_Constraint = typename PD::t_Constraint;
+  using t_Random_Updater = typename PD::t_Random_Updater;
 
   //! Values indicating how the algorithm ran
   struct Diagnostic : public PD::Diagnostic {

--- a/cpp/sopt/joint_map.h
+++ b/cpp/sopt/joint_map.h
@@ -16,11 +16,11 @@ namespace algorithm {
 
 template <class ALGORITHM>
 class JointMAP {
-  typedef typename ALGORITHM::t_Vector t_Vector;
-  typedef typename std::function<t_real(const t_Vector &)> t_Reg_Term;
-  typedef typename ALGORITHM::DiagnosticAndResult ResultType;
+  using t_Vector = typename ALGORITHM::t_Vector;
+  using t_Reg_Term = typename std::function<t_real (const t_Vector &)>;
+  using ResultType = typename ALGORITHM::DiagnosticAndResult;
   //! Type of the convergence function
-  typedef std::function<bool(t_Vector const &, t_Vector const &, t_real const)> t_IsConverged;
+  using t_IsConverged = std::function<bool (const t_Vector &, const t_Vector &, const t_real)>;
 
  public:
   //! Holds results and reg parameter
@@ -101,7 +101,7 @@ class JointMAP {
     sanity_check(this->algo_ptr_->gamma(), beta(), alpha());
     t_uint niters(0);
     bool converged = false;
-    typedef typename ALGORITHM::DiagnosticAndResult ResultType;
+    using ResultType = typename ALGORITHM::DiagnosticAndResult;
     ResultType result = (*(this->algo_ptr_))(std::forward<ARGS>(args)...);
     t_real gamma = 0;
     niters++;

--- a/cpp/sopt/l1_g_proximal.h
+++ b/cpp/sopt/l1_g_proximal.h
@@ -29,12 +29,12 @@ template <class SCALAR>
 class L1GProximal : public GProximal<SCALAR> {
 
 public:
-  typedef ForwardBackward<SCALAR> FB;
-  typedef typename FB::Real Real;
-  typedef typename FB::Scalar Scalar;
-  typedef typename FB::t_Vector t_Vector;
-  typedef typename FB::t_Proximal t_Proximal;
-  typedef typename FB::t_LinearTransform t_LinearTransform;
+  using FB = ForwardBackward<SCALAR>;
+  using Real = typename FB::Real;
+  using Scalar = typename FB::Scalar;
+  using t_Vector = typename FB::t_Vector;
+  using t_Proximal = typename FB::t_Proximal;
+  using t_LinearTransform = typename FB::t_LinearTransform;
 
   // In the constructor we need to construct the private l1_proximal_
   // object that contains the real implementation details. The tight_frame

--- a/cpp/sopt/l1_proximal.h
+++ b/cpp/sopt/l1_proximal.h
@@ -26,9 +26,9 @@ template <class SCALAR>
 class L1TightFrame {
  public:
   //! Underlying scalar type
-  typedef SCALAR Scalar;
+  using Scalar = SCALAR;
   //! Underlying real scalar type
-  typedef typename real_type<Scalar>::type Real;
+  using Real = typename real_type<Scalar>::type;
 
 #ifdef SOPT_MPI
   //! \brief MPI constructor with direct and adjoint space communicators
@@ -182,9 +182,9 @@ class L1 : protected L1TightFrame<SCALAR> {
 #endif
 
   //! Underlying scalar type
-  typedef typename L1TightFrame<SCALAR>::Scalar Scalar;
+  using Scalar = typename L1TightFrame<SCALAR>::Scalar;
   //! Underlying real scalar type
-  typedef typename L1TightFrame<SCALAR>::Real Real;
+  using Real = typename L1TightFrame<SCALAR>::Real;
 
   //! How did calling L1 go?
   struct Diagnostic {
@@ -391,7 +391,7 @@ void L1<SCALAR>::apply_constraints(Eigen::MatrixBase<T0> &out,
 template <class SCALAR>
 class L1<SCALAR>::FistaMixing {
  public:
-  typedef typename real_type<SCALAR>::type Real;
+  using Real = typename real_type<SCALAR>::type;
   FistaMixing() : t(1){};
   template <class T1>
   void operator()(Vector<SCALAR> &previous, Eigen::MatrixBase<T1> const &unmixed, t_uint iter) {
@@ -424,7 +424,7 @@ class L1<SCALAR>::NoMixing {
 template <class SCALAR>
 class L1<SCALAR>::Breaker {
  public:
-  typedef typename real_type<SCALAR>::type Real;
+  using Real = typename real_type<SCALAR>::type;
   //! Constructs a breaker object
   //! \param[in] objective: the first objective function
   //! \param[in] tolerance: Convergence criteria for convergence

--- a/cpp/sopt/l2_forward_backward.h
+++ b/cpp/sopt/l2_forward_backward.h
@@ -23,18 +23,18 @@ namespace algorithm {
 template <class SCALAR>
 class L2ForwardBackward {
   //! Underlying algorithm
-  typedef ForwardBackward<SCALAR> FB;
+  using FB = ForwardBackward<SCALAR>;
 
  public:
-  typedef typename FB::value_type value_type;
-  typedef typename FB::Scalar Scalar;
-  typedef typename FB::Real Real;
-  typedef typename FB::t_Vector t_Vector;
-  typedef typename FB::t_LinearTransform t_LinearTransform;
+  using value_type = typename FB::value_type;
+  using Scalar = typename FB::Scalar;
+  using Real = typename FB::Real;
+  using t_Vector = typename FB::t_Vector;
+  using t_LinearTransform = typename FB::t_LinearTransform;
   template <class T>
   using t_Proximal = std::function<void(t_Vector &, const T &, const t_Vector &)>;
-  typedef typename FB::t_Gradient t_Gradient;
-  typedef typename FB::t_IsConverged t_IsConverged;
+  using t_Gradient = typename FB::t_Gradient;
+  using t_IsConverged = typename FB::t_IsConverged;
 
   //! Values indicating how the algorithm ran
   struct Diagnostic : public FB::Diagnostic {

--- a/cpp/sopt/l2_primal_dual.h
+++ b/cpp/sopt/l2_primal_dual.h
@@ -18,19 +18,19 @@ namespace algorithm {
 template <class SCALAR>
 class ImagingPrimalDual {
   //! Underlying algorithm
-  typedef PrimalDual<SCALAR> PD;
+  using PD = PrimalDual<SCALAR>;
 
  public:
-  typedef typename PD::value_type value_type;
-  typedef typename PD::Scalar Scalar;
-  typedef typename PD::Real Real;
-  typedef typename PD::t_Vector t_Vector;
-  typedef typename PD::t_LinearTransform t_LinearTransform;
+  using value_type = typename PD::value_type;
+  using Scalar = typename PD::Scalar;
+  using Real = typename PD::Real;
+  using t_Vector = typename PD::t_Vector;
+  using t_LinearTransform = typename PD::t_LinearTransform;
   template <class T>
   using t_Proximal = std::function<void(t_Vector &, const T &, const t_Vector &)>;
-  typedef typename PD::t_IsConverged t_IsConverged;
-  typedef typename PD::t_Constraint t_Constraint;
-  typedef typename PD::t_Random_Updater t_Random_Updater;
+  using t_IsConverged = typename PD::t_IsConverged;
+  using t_Constraint = typename PD::t_Constraint;
+  using t_Random_Updater = typename PD::t_Random_Updater;
 
   //! Values indicating how the algorithm ran
   struct Diagnostic : public PD::Diagnostic {

--- a/cpp/sopt/linear_transform.h
+++ b/cpp/sopt/linear_transform.h
@@ -29,7 +29,7 @@ template <class VECTOR>
 class LinearTransform : public details::WrapFunction<VECTOR> {
  public:
   //! Type of the wrapped functions
-  typedef OperatorFunction<VECTOR> t_Function;
+  using t_Function = OperatorFunction<VECTOR>;
 
   //! Constructor
   //! \param[in] direct: function with signature void(VECTOR&, VECTOR const&) which applies a
@@ -136,16 +136,16 @@ namespace details {
 template <class EIGEN>
 class MatrixToLinearTransform {
   //! The underlying raw matrix type
-  typedef typename std::remove_const<typename std::remove_reference<EIGEN>::type>::type Raw;
+  using Raw = typename std::remove_const<typename std::remove_reference<EIGEN>::type>::type;
   //! The matrix underlying the expression
-  typedef typename Raw::PlainObject PlainMatrix;
+  using PlainMatrix = typename Raw::PlainObject;
 
  public:
   //! The output type
-  typedef
+  using PlainObject =
       typename std::conditional<std::is_base_of<Eigen::MatrixBase<PlainMatrix>, PlainMatrix>::value,
                                 Vector<typename PlainMatrix::Scalar>,
-                                Array<typename PlainMatrix::Scalar>>::type PlainObject;
+                                Array<typename PlainMatrix::Scalar>>::type;
   //! \brief Creates from an expression
   //! \details Expression is evaluated and the result stored internally. This object owns a
   //! copy of the matrix. It might share it with a few friendly neighbors.
@@ -177,7 +177,7 @@ class MatrixToLinearTransform {
 template <class EIGEN>
 class MatrixAdjointToLinearTransform {
  public:
-  typedef typename MatrixToLinearTransform<EIGEN>::PlainObject PlainObject;
+  using PlainObject = typename MatrixToLinearTransform<EIGEN>::PlainObject;
   //! \brief Creates from an expression
   //! \details Expression is evaluated and the result stored internally. This object owns a
   //! copy of the matrix. It might share it with a few friendly neighbors.

--- a/cpp/sopt/maths.h
+++ b/cpp/sopt/maths.h
@@ -48,18 +48,18 @@ class ProjectPositiveQuadrant<std::complex<SCALAR>> {
   }
 };
 
-//! Helper template typedef to instantiate soft_threshhold that takes an Eigen object
+//! Helper template type alias to instantiate soft_threshhold that takes an Eigen object
 template <class SCALAR>
-using SoftThreshhold = decltype(
-    std::bind(soft_threshhold<SCALAR>, std::placeholders::_1, typename real_type<SCALAR>::type(1)));
+using SoftThreshhold = decltype(std::bind(soft_threshhold<SCALAR>, std::placeholders::_1,
+                                          typename real_type<SCALAR>::type(1)));
 }  // namespace details
 
 //! Expression to create projection onto positive quadrant
 template <class T>
 Eigen::CwiseUnaryOp<const details::ProjectPositiveQuadrant<typename T::Scalar>, const T>
 positive_quadrant(Eigen::DenseBase<T> const &input) {
-  typedef details::ProjectPositiveQuadrant<typename T::Scalar> Projector;
-  typedef Eigen::CwiseUnaryOp<const Projector, const T> UnaryOp;
+  using Projector = details::ProjectPositiveQuadrant<typename T::Scalar>;
+  using UnaryOp = Eigen::CwiseUnaryOp<const Projector, const T>;
   return UnaryOp(input.derived(), Projector());
 }
 
@@ -68,8 +68,8 @@ template <class T>
 Eigen::CwiseUnaryOp<const details::SoftThreshhold<typename T::Scalar>, const T> soft_threshhold(
     Eigen::DenseBase<T> const &input,
     typename real_type<typename T::Scalar>::type const &threshhold) {
-  typedef typename T::Scalar Scalar;
-  typedef typename real_type<Scalar>::type Real;
+  using Scalar = typename T::Scalar;
+  using Real = typename real_type<Scalar>::type;
   return Eigen::CwiseUnaryOp<const details::SoftThreshhold<typename T::Scalar>, const T>{
       input.derived(), std::bind(soft_threshhold<Scalar>, std::placeholders::_1, Real(threshhold))};
 }
@@ -104,7 +104,7 @@ soft_threshhold(Eigen::DenseBase<T0> const &input, Eigen::DenseBase<T1> const &t
   if (input.size() != threshhold.size())
     SOPT_THROW("Threshhold and input should have the same size: ")
         << threshhold.size() << " vs " << input.size();
-  typedef typename T0::Scalar Complex;
+  using Complex = typename T0::Scalar;
   auto const func = [](Complex const &x, Complex const &t) -> Complex {
     return soft_threshhold(x, t.real());
   };

--- a/cpp/sopt/mpi/registered_types.h
+++ b/cpp/sopt/mpi/registered_types.h
@@ -8,10 +8,10 @@
 namespace sopt {
 namespace mpi {
 //! Type of an mpi tupe
-typedef decltype(MPI_CHAR) MPIType;
+using MPIType = decltype(MPI_CHAR);
 // Some MPI libraries don't actually have a type defined that will work in the above line
 // so the line below can be used instead
-// typedef int MPIType;
+// using MPIType = int;
 
 //! MPI type associated with a c++ type
 template <class T>
@@ -59,7 +59,7 @@ inline constexpr MPIType registered_type(T const &) {
 namespace details {
 template <typename... Ts>
 struct make_void {
-  typedef void type;
+  using type = void;
 };
 //! \brief Defines c++17 metafunction
 //! \details This implements [std::void_t](http://en.cppreference.com/w/cpp/types/void_t). See

--- a/cpp/sopt/padmm.h
+++ b/cpp/sopt/padmm.h
@@ -18,19 +18,19 @@ template <class SCALAR>
 class ProximalADMM {
  public:
   //! Scalar type
-  typedef SCALAR value_type;
+  using value_type = SCALAR;
   //! Scalar type
-  typedef value_type Scalar;
+  using Scalar = value_type;
   //! Real type
-  typedef typename real_type<Scalar>::type Real;
+  using Real = typename real_type<Scalar>::type;
   //! Type of then underlying vectors
-  typedef Vector<Scalar> t_Vector;
+  using t_Vector = Vector<Scalar>;
   //! Type of the Ψ and Ψ^H operations, as well as Φ and Φ^H
-  typedef LinearTransform<t_Vector> t_LinearTransform;
+  using t_LinearTransform = LinearTransform<t_Vector>;
   //! Type of the convergence function
-  typedef std::function<bool(t_Vector const &, t_Vector const &)> t_IsConverged;
+  using t_IsConverged = std::function<bool (const t_Vector &, const t_Vector &)>;
   //! Type of the convergence function
-  typedef ProximalFunction<Scalar> t_Proximal;
+  using t_Proximal = ProximalFunction<Scalar>;
 
   //! Values indicating how the algorithm ran
   struct Diagnostic {

--- a/cpp/sopt/positive_quadrant.h
+++ b/cpp/sopt/positive_quadrant.h
@@ -13,17 +13,17 @@ template <class ALGORITHM>
 class PositiveQuadrant {
  public:
   //! Underlying algorithm
-  typedef ALGORITHM Algorithm;
+  using Algorithm = ALGORITHM;
   //! Underlying scalar
-  typedef typename Algorithm::Scalar Scalar;
+  using Scalar = typename Algorithm::Scalar;
   //! Underlying vector
-  typedef typename Algorithm::t_Vector t_Vector;
+  using t_Vector = typename Algorithm::t_Vector;
   //! Underlying convergence functions
-  typedef typename Algorithm::t_IsConverged t_IsConverged;
+  using t_IsConverged = typename Algorithm::t_IsConverged;
   //! Underlying result type
-  typedef typename ALGORITHM::Diagnostic Diagnostic;
+  using Diagnostic = typename ALGORITHM::Diagnostic;
   //! Underlying result type
-  typedef typename ALGORITHM::DiagnosticAndResult DiagnosticAndResult;
+  using DiagnosticAndResult = typename ALGORITHM::DiagnosticAndResult;
 
   PositiveQuadrant(Algorithm const &algo) : algorithm_(algo) {}
   PositiveQuadrant(Algorithm &&algo) : algorithm_(std::move(algo)) {}

--- a/cpp/sopt/power_method.h
+++ b/cpp/sopt/power_method.h
@@ -136,15 +136,15 @@ template <class SCALAR>
 class PowerMethod {
  public:
   //! Scalar type
-  typedef SCALAR value_type;
+  using value_type = SCALAR;
   //! Scalar type
-  typedef value_type Scalar;
+  using Scalar = value_type;
   //! Real type
-  typedef typename real_type<Scalar>::type Real;
+  using Real = typename real_type<Scalar>::type;
   //! Type of then underlying vectors
-  typedef Vector<Scalar> t_Vector;
+  using t_Vector = Vector<Scalar>;
   //! Type of the Ψ and Ψ^H operations, as well as Φ and Φ^H
-  typedef LinearTransform<t_Vector> t_LinearTransform;
+  using t_LinearTransform = LinearTransform<t_Vector>;
 
   //! Holds result vector as well
   struct DiagnosticAndResult {

--- a/cpp/sopt/primal_dual.h
+++ b/cpp/sopt/primal_dual.h
@@ -23,23 +23,23 @@ template <class SCALAR>
 class PrimalDual {
  public:
   //! Scalar type
-  typedef SCALAR value_type;
+  using value_type = SCALAR;
   //! Scalar type
-  typedef value_type Scalar;
+  using Scalar = value_type;
   //! Real type
-  typedef typename real_type<Scalar>::type Real;
+  using Real = typename real_type<Scalar>::type;
   //! Type of then underlying vectors
-  typedef Vector<Scalar> t_Vector;
+  using t_Vector = Vector<Scalar>;
   //! Type of the Ψ and Ψ^H operations, as well as Φ and Φ^H
-  typedef LinearTransform<t_Vector> t_LinearTransform;
+  using t_LinearTransform = LinearTransform<t_Vector>;
   //! Type of the convergence function
-  typedef std::function<bool(t_Vector const &, t_Vector const &)> t_IsConverged;
+  using t_IsConverged = std::function<bool (const t_Vector &, const t_Vector &)>;
   //! Type of the constraint function
-  typedef std::function<void(t_Vector &, const t_Vector &)> t_Constraint;
+  using t_Constraint = std::function<void (t_Vector &, const t_Vector &)>;
   //! Type of random update function
-  typedef std::function<bool()> t_Random_Updater;
+  using t_Random_Updater = std::function<bool ()>;
   //! Type of the convergence function
-  typedef ProximalFunction<Scalar> t_Proximal;
+  using t_Proximal = ProximalFunction<Scalar>;
 
   //! Values indicating how the algorithm ran
   struct Diagnostic {

--- a/cpp/sopt/proximal.h
+++ b/cpp/sopt/proximal.h
@@ -30,7 +30,7 @@ class EuclidianNorm {
   void operator()(Vector<typename T0::Scalar> &out,
                   typename real_type<typename T0::Scalar>::type const &t,
                   Eigen::MatrixBase<T0> const &x) const {
-    typedef typename T0::Scalar Scalar;
+    using Scalar = typename T0::Scalar;
 #ifdef SOPT_MPI
     auto const norm = mpi::l2_norm(x, comm_);
 #else
@@ -157,7 +157,7 @@ void positive_quadrant(Vector<T> &out, typename real_type<T>::type, Vector<T> co
 template <class T>
 class L2Norm {
  public:
-  typedef typename real_type<T>::type Real;
+  using Real = typename real_type<T>::type;
   //! Constructs an L2 ball proximal of size gamma
   L2Norm() {}
 
@@ -182,7 +182,7 @@ class L2Norm {
 template <class T>
 class L2Ball {
  public:
-  typedef typename real_type<T>::type Real;
+  using Real = typename real_type<T>::type;
 //! Constructs an L2 ball proximal of size epsilon
 #ifdef SOPT_MPI
   L2Ball(Real epsilon, mpi::Communicator const &comm = mpi::Communicator())
@@ -246,8 +246,8 @@ class L2Ball {
 template <class T>
 class WeightedL2Ball : public L2Ball<T> {
  public:
-  typedef typename L2Ball<T>::Real Real;
-  typedef Vector<Real> t_Vector;
+  using Real = typename L2Ball<T>::Real;
+  using t_Vector = Vector<Real>;
 #ifdef SOPT_MPI
   //! Constructs an L2 ball proximal of size epsilon with given weights
   template <class T0>

--- a/cpp/sopt/proximal_expression.h
+++ b/cpp/sopt/proximal_expression.h
@@ -19,9 +19,9 @@ template <class FUNCTION, class DERIVED>
 class DelayedProximalFunction
     : public Eigen::ReturnByValue<DelayedProximalFunction<FUNCTION, DERIVED>> {
  public:
-  typedef typename DERIVED::PlainObject PlainObject;
-  typedef typename DERIVED::Index Index;
-  typedef typename real_type<typename DERIVED::Scalar>::type Real;
+  using PlainObject = typename DERIVED::PlainObject;
+  using Index = typename DERIVED::Index;
+  using Real = typename real_type<typename DERIVED::Scalar>::type;
 
   DelayedProximalFunction(FUNCTION const &func, Real const &gamma, DERIVED const &x)
       : func(func), gamma(gamma), x(x) {}
@@ -53,9 +53,9 @@ template <class FUNCTION, class DERIVED>
 class DelayedProximalEnveloppeFunction
     : public Eigen::ReturnByValue<DelayedProximalEnveloppeFunction<FUNCTION, DERIVED>> {
  public:
-  typedef typename DERIVED::PlainObject PlainObject;
-  typedef typename DERIVED::Index Index;
-  typedef typename real_type<typename DERIVED::Scalar>::type Real;
+  using PlainObject = typename DERIVED::PlainObject;
+  using Index = typename DERIVED::Index;
+  using Real = typename real_type<typename DERIVED::Scalar>::type;
 
   DelayedProximalEnveloppeFunction(FUNCTION const &func, DERIVED const &x) : func(func), x(x) {}
   DelayedProximalEnveloppeFunction(DelayedProximalEnveloppeFunction const &c)
@@ -92,11 +92,11 @@ namespace Eigen {
 namespace internal {
 template <class FUNCTION, class VECTOR>
 struct traits<sopt::proximal::details::DelayedProximalFunction<FUNCTION, VECTOR>> {
-  typedef typename VECTOR::PlainObject ReturnType;
+  using ReturnType = typename VECTOR::PlainObject;
 };
 template <class FUNCTION, class VECTOR>
 struct traits<sopt::proximal::details::DelayedProximalEnveloppeFunction<FUNCTION, VECTOR>> {
-  typedef typename VECTOR::PlainObject ReturnType;
+  using ReturnType = typename VECTOR::PlainObject;
 };
 }  // namespace internal
 }  // namespace Eigen

--- a/cpp/sopt/real_type.h
+++ b/cpp/sopt/real_type.h
@@ -43,12 +43,12 @@ class underlying_value_type;
 template <class T>
 class underlying_value_type<T, false> {
  public:
-  typedef T type;
+  using type = T;
 };
 template <class T>
 class underlying_value_type<T, true> {
  public:
-  typedef typename underlying_value_type<typename T::value_type>::type type;
+  using type = typename underlying_value_type<typename T::value_type>::type;
 };
 }  // namespace details
 //! Gets to the underlying real type

--- a/cpp/sopt/relative_variation.h
+++ b/cpp/sopt/relative_variation.h
@@ -13,9 +13,9 @@ template <class TYPE>
 class RelativeVariation {
  public:
   //! Underlying scalar type
-  typedef TYPE Scalar;
+  using Scalar = TYPE;
   //! Underlying scalar type
-  typedef typename real_type<Scalar>::type Real;
+  using Real = typename real_type<Scalar>::type;
   //! Maximum variation from one step to the next
   RelativeVariation(Real tolerance = 1e-12, std::string const &name = "")
       : tolerance_(tolerance), previous_(typename Array<Scalar>::Index(0)), name_(name){};
@@ -55,9 +55,9 @@ template <class TYPE>
 class ScalarRelativeVariation {
  public:
   //! Underlying scalar type
-  typedef TYPE Scalar;
+  using Scalar = TYPE;
   //! Underlying scalar type
-  typedef typename real_type<Scalar>::type Real;
+  using Real = typename real_type<Scalar>::type;
   //! Maximum variation from one step to the next
   ScalarRelativeVariation(Real relative_tolerance = 1e-12, Real absolute_tolerance = 1e-12,
                           std::string const &name = "")

--- a/cpp/sopt/reweighted.h
+++ b/cpp/sopt/reweighted.h
@@ -30,24 +30,24 @@ template <class ALGORITHM>
 class Reweighted {
  public:
   //! Inner-loop algorithm
-  typedef ALGORITHM Algorithm;
+  using Algorithm = ALGORITHM;
   //! Scalar type
-  typedef typename Algorithm::Scalar Scalar;
+  using Scalar = typename Algorithm::Scalar;
   //! Real type
-  typedef typename real_type<Scalar>::type Real;
+  using Real = typename real_type<Scalar>::type;
   //! Weight vector type
-  typedef Vector<Real> WeightVector;
+  using WeightVector = Vector<Real>;
   //! Type of then underlying vectors
-  typedef typename Algorithm::t_Vector XVector;
+  using XVector = typename Algorithm::t_Vector;
   //! Type of the convergence function
-  typedef ConvergenceFunction<Scalar> t_IsConverged;
+  using t_IsConverged = ConvergenceFunction<Scalar>;
   //! \brief Type of the function that is subject to reweighting
   //! \details E.g. \f$Ψ^Tx\f$. Note that l1-norm is not applied here.
-  typedef std::function<XVector(Algorithm const &, XVector const &)> t_Reweightee;
+  using t_Reweightee = std::function<XVector (const Algorithm &, const XVector &)>;
   //! Type of the function to set weights
-  typedef std::function<void(Algorithm &, WeightVector const &)> t_SetWeights;
+  using t_SetWeights = std::function<void (Algorithm &, const WeightVector &)>;
   //! Function to update delta at each turn
-  typedef std::function<Real(Real)> t_DeltaUpdate;
+  using t_DeltaUpdate = std::function<Real (Real)>;
 
   //! output from running reweighting scheme
   struct ReweightedResult {
@@ -249,8 +249,8 @@ template <class SCALAR>
 Reweighted<PositiveQuadrant<ImagingProximalADMM<SCALAR>>> reweighted(
     ImagingProximalADMM<SCALAR> const &algo) {
   auto const posq = positive_quadrant(algo);
-  typedef typename std::remove_const<decltype(posq)>::type Algorithm;
-  typedef Reweighted<Algorithm> RW;
+  using Algorithm = typename std::remove_const<decltype(posq)>::type;
+  using RW = Reweighted<Algorithm>;
   auto const reweightee =
       [](Algorithm const &posq, typename RW::XVector const &x) -> typename RW::XVector {
     return posq.algorithm().Psi().adjoint() * x;
@@ -272,8 +272,8 @@ positive_quadrant(Eigen::DenseBase<T> const &input);
 template <class SCALAR>
 Reweighted<PositiveQuadrant<PrimalDual<SCALAR>>> reweighted(PrimalDual<SCALAR> const &algo) {
   auto const posq = positive_quadrant(algo);
-  typedef typename std::remove_const<decltype(posq)>::type Algorithm;
-  typedef Reweighted<Algorithm> RW;
+  using Algorithm = typename std::remove_const<decltype(posq)>::type;
+  using RW = Reweighted<Algorithm>;
   auto const reweightee =
       [](Algorithm const &posq, typename RW::XVector const &x) -> typename RW::XVector {
     return posq.algorithm().Psi().adjoint() * x;

--- a/cpp/sopt/sdmm.h
+++ b/cpp/sopt/sdmm.h
@@ -36,19 +36,19 @@ class SDMM {
     Vector<SCALAR> x;
   };
   //! Scalar type
-  typedef SCALAR value_type;
+  using value_type = SCALAR;
   //! Scalar type
-  typedef value_type Scalar;
+  using Scalar = value_type;
   //! Real type
-  typedef typename real_type<Scalar>::type Real;
+  using Real = typename real_type<Scalar>::type;
   //! Type of then underlying vectors
-  typedef Vector<SCALAR> t_Vector;
+  using t_Vector = Vector<SCALAR>;
   //! Type of the A and A^H operations
-  typedef LinearTransform<t_Vector> t_LinearTransform;
+  using t_LinearTransform = LinearTransform<t_Vector>;
   //! Type of the proximal functions
-  typedef ProximalFunction<SCALAR> t_Proximal;
+  using t_Proximal = ProximalFunction<SCALAR>;
   //! Type of the convergence function
-  typedef ConvergenceFunction<SCALAR> t_IsConverged;
+  using t_IsConverged = ConvergenceFunction<SCALAR>;
 
   SDMM()
       : itermax_(std::numeric_limits<t_uint>::max()),
@@ -178,7 +178,7 @@ class SDMM {
   std::vector<t_Proximal> proximals_;
 
   //! Type of the list of vectors
-  typedef std::vector<t_Vector> t_Vectors;
+  using t_Vectors = std::vector<t_Vector>;
   //! Conjugate gradient step
   virtual ConjugateGradient::Diagnostic solve_for_xn(t_Vector &out, t_Vectors const &y,
                                                      t_Vectors const &z) const;

--- a/cpp/sopt/tf_g_proximal.h
+++ b/cpp/sopt/tf_g_proximal.h
@@ -29,12 +29,12 @@ template <class SCALAR>
 class TFGProximal : public GProximal<SCALAR> {
 
 public:
-  typedef ForwardBackward<SCALAR> FB;
-  typedef typename FB::Real Real;
-  typedef typename FB::Scalar Scalar;
-  typedef typename FB::t_Vector t_Vector;
-  typedef typename FB::t_Proximal t_Proximal;
-  typedef typename FB::t_LinearTransform t_LinearTransform;
+  using FB = ForwardBackward<SCALAR>;
+  using Real = typename FB::Real;
+  using Scalar = typename FB::Scalar;
+  using t_Vector = typename FB::t_Vector;
+  using t_Proximal = typename FB::t_Proximal;
+  using t_LinearTransform = typename FB::t_LinearTransform;
 
   // The constructor constructs a cppflow model object from a saved model saved
   // to the file filename

--- a/cpp/sopt/tv_primal_dual.h
+++ b/cpp/sopt/tv_primal_dual.h
@@ -18,19 +18,19 @@ namespace algorithm {
 template <class SCALAR>
 class TVPrimalDual {
   //! Underlying algorithm
-  typedef PrimalDual<SCALAR> PD;
+  using PD = PrimalDual<SCALAR>;
 
  public:
-  typedef typename PD::value_type value_type;
-  typedef typename PD::Scalar Scalar;
-  typedef typename PD::Real Real;
-  typedef typename PD::t_Vector t_Vector;
-  typedef typename PD::t_LinearTransform t_LinearTransform;
+  using value_type = typename PD::value_type;
+  using Scalar = typename PD::Scalar;
+  using Real = typename PD::Real;
+  using t_Vector = typename PD::t_Vector;
+  using t_LinearTransform = typename PD::t_LinearTransform;
   template <class T>
   using t_Proximal = std::function<void(t_Vector &, const T &, const t_Vector &)>;
-  typedef typename PD::t_IsConverged t_IsConverged;
-  typedef typename PD::t_Constraint t_Constraint;
-  typedef typename PD::t_Random_Updater t_Random_Updater;
+  using t_IsConverged = typename PD::t_IsConverged;
+  using t_Constraint = typename PD::t_Constraint;
+  using t_Random_Updater = typename PD::t_Random_Updater;
 
   //! Values indicating how the algorithm ran
   struct Diagnostic : public PD::Diagnostic {

--- a/cpp/sopt/types.h
+++ b/cpp/sopt/types.h
@@ -10,13 +10,13 @@
 namespace sopt {
 
 //! Root of the type hierarchy for signed integers
-typedef int t_int;
+using t_int = int;
 //! Root of the type hierarchy for unsigned integers
-typedef size_t t_uint;
+using t_uint = size_t;
 //! Root of the type hierarchy for real numbers
-typedef double t_real;
+using t_real = double;
 //! Root of the type hierarchy for (real) complex numbers
-typedef std::complex<t_real> t_complex;
+using t_complex = std::complex<t_real>;
 
 //! \brief A vector of a given type
 //! \details Operates as mathematical vector.

--- a/cpp/sopt/wavelets/sara.h
+++ b/cpp/sopt/wavelets/sara.h
@@ -178,7 +178,7 @@ void SARA::indirect(Eigen::ArrayBase<T1> const &coeffs, Eigen::ArrayBase<T0> &si
 
 template <class T0>
 typename T0::PlainObject SARA::indirect(Eigen::ArrayBase<T0> const &coeffs) const {
-  typedef decltype(this->front().indirect(coeffs)) t_Output;
+  using t_Output = decltype(this->front().indirect(coeffs));
   t_Output signal = t_Output::Zero(coeffs.rows(), coeffs.cols() / size());
   (*this).indirect(coeffs, signal);
   return signal;
@@ -186,7 +186,7 @@ typename T0::PlainObject SARA::indirect(Eigen::ArrayBase<T0> const &coeffs) cons
 
 template <class T0>
 typename T0::PlainObject SARA::direct(Eigen::ArrayBase<T0> const &signal) const {
-  typedef decltype(this->front().direct(signal)) t_Output;
+  using t_Output = decltype(this->front().direct(signal));
   t_Output result = t_Output::Zero(signal.rows(), signal.cols() * size());
   (*this).direct(result, signal);
   return result;

--- a/cpp/sopt/wavelets/wavelet_data.h
+++ b/cpp/sopt/wavelets/wavelet_data.h
@@ -11,9 +11,9 @@ namespace wavelets {
 //! Holds wavelets coefficients
 struct WaveletData {
   //! Type of the underlying scalar
-  typedef t_real t_scalar;
+  using t_scalar = t_real;
   //! Type of the underlying vector
-  typedef Array<t_real> t_vector;
+  using t_vector = Array<t_real>;
   //! Wavelet coefficient per-se
   t_vector const coefficients;
 

--- a/cpp/sopt/wrapper.h
+++ b/cpp/sopt/wrapper.h
@@ -15,8 +15,8 @@ namespace details {
 template <class FUNCTION, class DERIVED>
 class AppliedFunction : public Eigen::ReturnByValue<AppliedFunction<FUNCTION, DERIVED>> {
  public:
-  typedef typename DERIVED::PlainObject PlainObject;
-  typedef typename DERIVED::Index Index;
+  using PlainObject = typename DERIVED::PlainObject;
+  using Index = typename DERIVED::Index;
 
   AppliedFunction(FUNCTION const &func, DERIVED const &x, Index rows)
       : func(func), x(x), rows_(rows) {}
@@ -46,7 +46,7 @@ template <class VECTOR>
 class WrapFunction {
  public:
   //! Type of function wrapped here
-  typedef OperatorFunction<VECTOR> t_Function;
+  using t_Function = OperatorFunction<VECTOR>;
 
   //! Initializes the wrapper
   //! \param[in] func: function to wrap
@@ -139,7 +139,7 @@ namespace Eigen {
 namespace internal {
 template <class FUNCTION, class VECTOR>
 struct traits<sopt::details::AppliedFunction<FUNCTION, VECTOR>> {
-  typedef typename VECTOR::PlainObject ReturnType;
+  using ReturnType = typename VECTOR::PlainObject;
 };
 }  // namespace internal
 }  // namespace Eigen

--- a/cpp/tests/bisection_method.cc
+++ b/cpp/tests/bisection_method.cc
@@ -6,9 +6,9 @@
 #include "sopt/bisection_method.h"
 #include "sopt/types.h"
 
-typedef sopt::t_real Scalar;
-typedef sopt::Vector<Scalar> t_Vector;
-typedef sopt::Matrix<Scalar> t_Matrix;
+using Scalar = sopt::t_real;
+using t_Vector = sopt::Vector<Scalar>;
+using t_Matrix = sopt::Matrix<Scalar>;
 
 const Scalar a = -0.5;
 const Scalar b = 1.;

--- a/cpp/tests/chained_operators.cc
+++ b/cpp/tests/chained_operators.cc
@@ -8,8 +8,8 @@
 TEST_CASE("Linear Transforms", "[ops]") {
   using namespace sopt;
 
-  typedef int SCALAR;
-  typedef Vector<SCALAR> t_Vector;
+  using SCALAR = int;
+  using t_Vector = Vector<SCALAR>;
   auto const N = 5;
 
   SECTION("1 Functions") {

--- a/cpp/tests/cppflow_model.cc
+++ b/cpp/tests/cppflow_model.cc
@@ -16,8 +16,8 @@
 #include "tools_for_tests/tiffwrappers.h"
 
 
-typedef double Scalar;
-typedef sopt::Image<Scalar> Image;
+using Scalar = double;
+using Image = sopt::Image<Scalar>;
 
 
 TEST_CASE("Cppflow Model"){
@@ -35,7 +35,7 @@ TEST_CASE("Cppflow Model"){
   cppflow::model model(std::string(sopt::notinstalled::models_directory() + "/DnCNN/snr_15_model.pb/"));
 
   // Run model on image
-  // TODO: Automatically detect the string parameters, see issue #320 
+  // TODO: Automatically detect the string parameters, see issue #320
   auto output_vector = model({{"serving_default_input0:0", input_tensor}}, {"StatefulPartitionedCall:0"});
 
   // Get values from output (has to be same type as the input to the model - float)
@@ -44,7 +44,7 @@ TEST_CASE("Cppflow Model"){
   auto output_image = sopt::cppflowutils::convert_tensor_to_image(output_tensor, image_rows, image_cols);
 
   // compare input image to cleaned output image
-  // calculate mean squared error sum_i ( ( x_true(i) - x_est(i) ) **2 ) 
+  // calculate mean squared error sum_i ( ( x_true(i) - x_est(i) ) **2 )
   // check this is less than the number of pixels * 0.01
 
   auto mse = (image - output_image).square().sum() / image.size();

--- a/cpp/tests/credible_region.cc
+++ b/cpp/tests/credible_region.cc
@@ -5,9 +5,9 @@
 #include "sopt/types.h"
 
 using namespace sopt;
-typedef t_complex Scalar;
-typedef Vector<Scalar> t_Vector;
-typedef Image<Scalar> t_Image;
+using Scalar = t_complex;
+using t_Vector = Vector<Scalar>;
+using t_Image = Image<Scalar>;
 t_uint rows = 128;
 t_uint cols = 128;
 t_uint N = rows * cols;

--- a/cpp/tests/forward_backward.cc
+++ b/cpp/tests/forward_backward.cc
@@ -22,9 +22,9 @@ sopt::t_int random_integer(sopt::t_int min, sopt::t_int max) {
   return uniform_dist(*mersenne);
 };
 
-typedef sopt::t_real Scalar;
-typedef sopt::Vector<Scalar> t_Vector;
-typedef sopt::t_real t_real;
+using Scalar = sopt::t_real;
+using t_Vector = sopt::Vector<Scalar>;
+using t_real = sopt::t_real;
 auto const N = 5;
 
 TEST_CASE("Forward Backward with ||x - x0||_2^2 function", "[fb]") {
@@ -77,7 +77,7 @@ TEST_CASE("Check type returned on setting variables") {
   CHECK(is_imaging_proximal_ref<decltype(fb.l2_gradient(grad))>::value);
   CHECK(is_imaging_proximal_ref<decltype(fb.residual_convergence(1.001))>::value);
   CHECK(is_imaging_proximal_ref<decltype(fb.target(Vector<double>::Zero(0)))>::value);
-  typedef ConvergenceFunction<double> ConvFunc;
+  using ConvFunc = ConvergenceFunction<double>;
   CHECK(is_imaging_proximal_ref<decltype(fb.is_converged(std::declval<ConvFunc>()))>::value);
   CHECK(is_imaging_proximal_ref<decltype(fb.is_converged(std::declval<ConvFunc &>()))>::value);
   CHECK(is_imaging_proximal_ref<decltype(fb.is_converged(std::declval<ConvFunc &&>()))>::value);
@@ -92,7 +92,7 @@ TEST_CASE("Check type returned on setting variables") {
   CHECK(is_l1_g_proximal_ref<decltype(gp->l1_proximal_itermax(50))>::value);
   CHECK(is_l1_g_proximal_ref<decltype(gp->l1_proximal_positivity_constraint(true))>::value);
   CHECK(is_l1_g_proximal_ref<decltype(gp->l1_proximal_real_constraint(true))>::value);
-  typedef LinearTransform<Vector<double>> LinTrans;
+  using LinTrans = LinearTransform<Vector<double>>;
   CHECK(is_l1_g_proximal_ref<decltype(gp->Psi(linear_transform_identity<double>()))>::value);
   CHECK(is_l1_g_proximal_ref<decltype(gp->Psi(std::declval<LinTrans>()))>::value);
   CHECK(is_l1_g_proximal_ref<decltype(gp->Psi(std::declval<LinTrans &&>()))>::value);

--- a/cpp/tests/gradient_operator.cc
+++ b/cpp/tests/gradient_operator.cc
@@ -14,14 +14,14 @@
 
 TEST_CASE("Gradient Operator") {
   using namespace sopt;
-  // Some typedefs for simplicity
-  typedef double Scalar;
+  // Some type aliases for simplicity
+  using Scalar = double;
 
-  typedef sopt::Vector<Scalar> Vector;
+  using Vector = sopt::Vector<Scalar>;
 
-  typedef sopt::Matrix<Scalar> Matrix;
+  using Matrix = sopt::Matrix<Scalar>;
 
-  typedef sopt::Image<Scalar> Image;
+  using Image = sopt::Image<Scalar>;
 
   Image const image = sopt::notinstalled::read_standard_tiff("cameraman256");
   auto const psi = sopt::gradient_operator::gradient_operator<Scalar>(image.rows(), image.cols());

--- a/cpp/tests/inpainting.cc
+++ b/cpp/tests/inpainting.cc
@@ -24,10 +24,10 @@
 
 // \min_{x} ||\Psi^Tx||_1 \quad \mbox{s.t.} \quad ||y - Ax||_2 < \epsilon and x \geq 0
 
-typedef double Scalar;
-typedef sopt::Vector<Scalar> Vector;
-typedef sopt::Matrix<Scalar> Matrix;
-typedef sopt::Image<Scalar> Image;
+using Scalar = double;
+using Vector = sopt::Vector<Scalar>;
+using Matrix = sopt::Matrix<Scalar>;
+using Image = sopt::Image<Scalar>;
 
 TEST_CASE("Inpainting"){
   extern std::unique_ptr<std::mt19937_64> mersenne;

--- a/cpp/tests/linear_transform.cc
+++ b/cpp/tests/linear_transform.cc
@@ -7,9 +7,9 @@
 TEST_CASE("Linear Transforms", "[ops]") {
   using namespace sopt;
 
-  typedef int SCALAR;
-  typedef Array<SCALAR> t_Vector;
-  typedef Image<SCALAR> t_Matrix;
+  using SCALAR = int;
+  using t_Vector = Array<SCALAR>;
+  using t_Matrix = Image<SCALAR>;
   auto const N = 10;
 
   SECTION("Functions") {
@@ -60,9 +60,9 @@ TEST_CASE("Linear Transforms", "[ops]") {
 TEST_CASE("Array of Linear transforms", "[ops]") {
   using namespace sopt;
 
-  typedef int SCALAR;
-  typedef Vector<SCALAR> t_Vector;
-  typedef Matrix<SCALAR> t_Matrix;
+  using SCALAR = int;
+  using t_Vector = Vector<SCALAR>;
+  using t_Matrix = Matrix<SCALAR>;
 
   auto const N = 10;
   t_Vector const x = t_Vector::Random(N) * 5;

--- a/cpp/tests/maths.cc
+++ b/cpp/tests/maths.cc
@@ -117,7 +117,7 @@ TEST_CASE("Soft threshhold", "[utility][threshhold]") {
 }
 
 TEST_CASE("Sampling", "[utility][sampling]") {
-  typedef sopt::Vector<int> t_Vector;
+  using t_Vector = sopt::Vector<int>;
   t_Vector const input = t_Vector::Random(12);
 
   sopt::Sampling const sampling(12, {1, 3, 6, 5});

--- a/cpp/tests/padmm.cc
+++ b/cpp/tests/padmm.cc
@@ -14,9 +14,9 @@ sopt::t_int random_integer(sopt::t_int min, sopt::t_int max) {
   return uniform_dist(*mersenne);
 };
 
-typedef sopt::t_real Scalar;
-typedef sopt::Vector<Scalar> t_Vector;
-typedef sopt::Matrix<Scalar> t_Matrix;
+using Scalar = sopt::t_real;
+using t_Vector = sopt::Vector<Scalar>;
+using t_Matrix = sopt::Matrix<Scalar>;
 
 auto const N = 5;
 
@@ -67,13 +67,13 @@ TEST_CASE("Check type returned on setting variables") {
   CHECK(is_imaging_proximal_ref<decltype(admm.lagrange_update_scale(0.9))>::value);
   CHECK(is_imaging_proximal_ref<decltype(admm.nu(1e0))>::value);
   CHECK(is_imaging_proximal_ref<decltype(admm.target(Vector<double>::Zero(0)))>::value);
-  typedef ConvergenceFunction<double> ConvFunc;
+  using ConvFunc = ConvergenceFunction<double>;
   CHECK(is_imaging_proximal_ref<decltype(admm.is_converged(std::declval<ConvFunc>()))>::value);
   CHECK(is_imaging_proximal_ref<decltype(admm.is_converged(std::declval<ConvFunc &>()))>::value);
   CHECK(is_imaging_proximal_ref<decltype(admm.is_converged(std::declval<ConvFunc &&>()))>::value);
   CHECK(is_imaging_proximal_ref<decltype(
             admm.is_converged(std::declval<ConvFunc const &>()))>::value);
-  typedef LinearTransform<Vector<double>> LinTrans;
+  using LinTrans = LinearTransform<Vector<double>>;
   CHECK(is_imaging_proximal_ref<decltype(admm.Phi(linear_transform_identity<double>()))>::value);
   CHECK(is_imaging_proximal_ref<decltype(admm.Phi(std::declval<LinTrans>()))>::value);
   CHECK(is_imaging_proximal_ref<decltype(admm.Phi(std::declval<LinTrans &&>()))>::value);

--- a/cpp/tests/padmm_warm_start.cc
+++ b/cpp/tests/padmm_warm_start.cc
@@ -7,9 +7,9 @@
 #include "sopt/proximal.h"
 #include "sopt/types.h"
 
-typedef sopt::t_real Scalar;
-typedef sopt::Vector<Scalar> t_Vector;
-typedef sopt::Matrix<Scalar> t_Matrix;
+using Scalar = sopt::t_real;
+using t_Vector = sopt::Vector<Scalar>;
+using t_Matrix = sopt::Matrix<Scalar>;
 
 auto const N = 30;
 SCENARIO("ProximalADMM with warm start", "[padmm][integration]") {

--- a/cpp/tests/power_method.cc
+++ b/cpp/tests/power_method.cc
@@ -7,7 +7,7 @@
 
 TEST_CASE("Power Method") {
   using namespace sopt;
-  typedef t_real Scalar;
+  using Scalar = t_real;
   auto const N = 10;
   Eigen::EigenSolver<Matrix<Scalar>> es;
   Matrix<Scalar> A(N, N);
@@ -46,7 +46,7 @@ TEST_CASE("Power Method") {
 
 TEST_CASE("Power Method (from Purify)") {
   using namespace sopt;
-  typedef t_real Scalar;
+  using Scalar = t_real;
   auto const N = 10;
   const t_uint power_iters = 100000;
   const t_real power_tol = 1e-6;

--- a/cpp/tests/primal_dual.cc
+++ b/cpp/tests/primal_dual.cc
@@ -10,9 +10,9 @@
 #include "sopt/proximal.h"
 #include "sopt/types.h"
 
-typedef sopt::t_real Scalar;
-typedef sopt::Vector<Scalar> t_Vector;
-typedef sopt::Matrix<Scalar> t_Matrix;
+using Scalar = sopt::t_real;
+using t_Vector = sopt::Vector<Scalar>;
+using t_Matrix = sopt::Matrix<Scalar>;
 
 auto const N = 5;
 

--- a/cpp/tests/proximal.cc
+++ b/cpp/tests/proximal.cc
@@ -88,7 +88,7 @@ TEST_CASE("Tight-Frame L1 proximal", "[l1][proximal]") {
   using namespace sopt;
   auto l1 = proximal::L1TightFrame<t_complex>();
   auto check_is_minimum = [&l1](Vector<t_complex> const &x, t_real gamma = 1e0) {
-    typedef t_complex Scalar;
+    using Scalar = t_complex;
     Vector<t_complex> const p = l1(gamma, x);
     auto const mini = l1.objective(x, p, gamma);
     auto const eps = 1e-4;
@@ -141,7 +141,7 @@ TEST_CASE("Tight-Frame L1 proximal", "[l1][proximal]") {
 
 TEST_CASE("L1 proximal utilities", "[l1][utilities]") {
   using namespace sopt;
-  typedef t_complex Scalar;
+  using Scalar = t_complex;
 
   SECTION("Mixing") {
     auto const input = Vector<Scalar>::Random(10).eval();
@@ -201,7 +201,7 @@ TEST_CASE("L1 proximal utilities", "[l1][utilities]") {
 
 TEST_CASE("L1 proximal", "[l1][proximal]") {
   using namespace sopt;
-  typedef t_complex Scalar;
+  using Scalar = t_complex;
   auto l1 = proximal::L1<Scalar>().tolerance(1e-10);
 
   Vector<Scalar> const input = Vector<Scalar>::Random(4);

--- a/cpp/tests/reweighted.cc
+++ b/cpp/tests/reweighted.cc
@@ -8,12 +8,12 @@
 
 using namespace sopt;
 
-//! \brief Minimum set of functions and typedefs needed by reweighting
+//! \brief Minimum set of functions and type aliases needed by reweighting
 //! \details The attributes are public and static so we can access them during the tests.
 struct DummyAlgorithm {
-  typedef t_real Scalar;
-  typedef Vector<Scalar> t_Vector;
-  typedef ConvergenceFunction<Scalar> t_IsConverged;
+  using Scalar = t_real;
+  using t_Vector = Vector<Scalar>;
+  using t_IsConverged = ConvergenceFunction<Scalar>;
 
   struct DiagnosticAndResult {
     //! Expected by reweighted algorithm

--- a/cpp/tests/sara.cc
+++ b/cpp/tests/sara.cc
@@ -16,7 +16,7 @@ TEST_CASE("Check SARA implementation mechanically", "[wavelet]") {
   using namespace sopt::wavelets;
   using namespace sopt;
 
-  typedef std::tuple<std::string, sopt::t_uint> t_i;
+  using t_i = std::tuple<std::string, sopt::t_uint>;
   SARA const sara{t_i{std::string{"DB3"}, 1u}, t_i{std::string{"DB1"}, 2u},
                   t_i{std::string{"DB1"}, 3u}};
   SECTION("Construction and vector functionality") {

--- a/cpp/tests/sdmm.cc
+++ b/cpp/tests/sdmm.cc
@@ -13,9 +13,9 @@ sopt::t_int random_integer(sopt::t_int min, sopt::t_int max) {
   return uniform_dist(*mersenne);
 };
 
-typedef sopt::t_real Scalar;
-typedef sopt::Vector<Scalar> t_Vector;
-typedef sopt::Matrix<Scalar> t_Matrix;
+using Scalar = sopt::t_real;
+using t_Vector = sopt::Vector<Scalar>;
+using t_Matrix = sopt::Matrix<Scalar>;
 
 auto const N = 4;
 

--- a/cpp/tests/sdmm_warm_start.cc
+++ b/cpp/tests/sdmm_warm_start.cc
@@ -7,9 +7,9 @@
 #include "sopt/sdmm.h"
 #include "sopt/types.h"
 
-typedef sopt::t_real Scalar;
-typedef sopt::Vector<Scalar> t_Vector;
-typedef sopt::Matrix<Scalar> t_Matrix;
+using Scalar = sopt::t_real;
+using t_Vector = sopt::Vector<Scalar>;
+using t_Matrix = sopt::Matrix<Scalar>;
 
 auto const N = 30;
 SCENARIO("SDMM with warm start", "[sdmm][integration]") {

--- a/cpp/tests/serial_vs_parallel_padmm.cc
+++ b/cpp/tests/serial_vs_parallel_padmm.cc
@@ -26,10 +26,10 @@ TEST_CASE("Parallel vs serial inpainting") {
   auto const split_comm = world.split(world.is_root());
   if (world.size() < 2) return;
 
-  // Some typedefs for simplicity
-  typedef double Scalar;
-  typedef sopt::Vector<Scalar> Vector;
-  typedef sopt::Image<Scalar> Image;
+  // Some type aliases for simplicity
+  using Scalar = double;
+  using Vector = sopt::Vector<Scalar>;
+  using Image = sopt::Image<Scalar>;
 
   std::string const input = "cameraman256";
   // Read input file

--- a/cpp/tests/tf_inpainting.cc
+++ b/cpp/tests/tf_inpainting.cc
@@ -23,10 +23,10 @@
 
 // \min_{x} ||\Psi^Tx||_1 \quad \mbox{s.t.} \quad ||y - Ax||_2 < \epsilon and x \geq 0
 
-typedef double Scalar;
-typedef sopt::Vector<Scalar> Vector;
-typedef sopt::Matrix<Scalar> Matrix;
-typedef sopt::Image<Scalar> Image;
+using Scalar = double;
+using Vector = sopt::Vector<Scalar>;
+using Matrix = sopt::Matrix<Scalar>;
+using Image = sopt::Image<Scalar>;
 
 TEST_CASE("Inpainting"){
   extern std::unique_ptr<std::mt19937_64> mersenne;

--- a/cpp/tests/wavelets.cc
+++ b/cpp/tests/wavelets.cc
@@ -8,7 +8,7 @@
 #include "sopt/wavelets/wavelet_data.h"
 #include "sopt/wavelets/wavelets.h"
 
-typedef sopt::Array<sopt::t_uint> t_iVector;
+using t_iVector = sopt::Array<sopt::t_uint>;
 t_iVector even(t_iVector const &x) {
   t_iVector result((x.size() + 1) / 2);
   for (t_iVector::Index i(0); i < x.size(); i += 2) result(i / 2) = x(i);
@@ -22,7 +22,7 @@ t_iVector odd(t_iVector const &x) {
 template <class T>
 Eigen::Array<typename T::Scalar, T::RowsAtCompileTime, T::ColsAtCompileTime> upsample(
     Eigen::ArrayBase<T> const &input) {
-  typedef Eigen::Array<typename T::Scalar, T::RowsAtCompileTime, T::ColsAtCompileTime> Matrix;
+  using Matrix = Eigen::Array<typename T::Scalar, T::RowsAtCompileTime, T::ColsAtCompileTime>;
   Matrix result(input.size() * 2);
   for (t_iVector::Index i(0); i < input.size(); ++i) {
     result(2 * i) = input(i);

--- a/cpp/tests/wrapper.cc
+++ b/cpp/tests/wrapper.cc
@@ -5,9 +5,9 @@
 
 TEST_CASE("Function wrappers", "[utility]") {
   using namespace sopt;
-  typedef Array<int> t_Array;
-  typedef t_Array &t_RefArray;
-  typedef t_Array const t_ConstRefArray;
+  using t_Array = Array<int>;
+  using t_RefArray = t_Array&;
+  using t_ConstRefArray = t_Array const;
 
   SECTION("Square function") {
     auto func = [](t_RefArray output, t_ConstRefArray const &input) { output = input * 2 + 1; };

--- a/cpp/tools_for_tests/cdata.h
+++ b/cpp/tools_for_tests/cdata.h
@@ -9,7 +9,7 @@ namespace sopt {
 // Wraps calls to sampling and wavelets to C style
 template <class T>
 struct CData {
-  typedef Eigen::Matrix<T, Eigen::Dynamic, 1> t_Vector;
+  using t_Vector = Eigen::Matrix<T, Eigen::Dynamic, 1>;
   typename t_Vector::Index nin, nout;
   sopt::LinearTransform<t_Vector> const &transform;
   t_uint direct_calls, adjoint_calls;
@@ -18,7 +18,7 @@ struct CData {
 template <class T>
 void direct_transform(void *out, void *in, void **data) {
   CData<T> const &cdata = *(CData<T> *)data;
-  typedef Eigen::Matrix<T, Eigen::Dynamic, 1> t_Vector;
+  using t_Vector = Eigen::Matrix<T, Eigen::Dynamic, 1>;
   t_Vector const eval = cdata.transform * t_Vector::Map((T *)in, cdata.nin);
   ++(((CData<T> *)data)->direct_calls);
   t_Vector::Map((T *)out, cdata.nout) = eval;
@@ -26,7 +26,7 @@ void direct_transform(void *out, void *in, void **data) {
 template <class T>
 void adjoint_transform(void *out, void *in, void **data) {
   CData<T> const &cdata = *(CData<T> *)data;
-  typedef Eigen::Matrix<T, Eigen::Dynamic, 1> t_Vector;
+  using t_Vector = Eigen::Matrix<T, Eigen::Dynamic, 1>;
   t_Vector const eval = cdata.transform.adjoint() * t_Vector::Map((T *)in, cdata.nout);
   ++(((CData<T> *)data)->adjoint_calls);
   t_Vector::Map((T *)out, cdata.nin) = eval;


### PR DESCRIPTION
Replacing C-style typedefs with `using` aliases. Closes #371.

### Reasoning from [learncpp.com](https://www.learncpp.com/cpp-tutorial/typedefs-and-type-aliases/)

> Typedefs are still in C++ for backwards compatibility reasons, but they have been largely replaced by type aliases in modern C++.
> 
> Typedefs have a few syntactical issues. 
> 1. First, it’s easy to forget whether the name of the typedef or the name of the type to alias comes first. Which is correct?
> ```
> typedef Distance double; // incorrect (typedef name first)
> typedef double Distance; // correct (aliased type name first)
> ```
> It’s easy to get backwards. Fortunately, in such cases, the compiler will complain.
> 
> 2. Second, the syntax for typedefs can get ugly with more complex types. For example, here is a hard-to-read typedef, along with an equivalent (and slightly easier to read) type alias:
> ```
> typedef int (*FcnType)(double, char); // FcnType hard to find
> using FcnType = int(*)(double, char); // FcnType easier to find
> ```
> In the above typedef definition, the name of the new type (FcnType) is buried in the middle of the definition, whereas in the type alias, the name of the new type and the rest of the definition are separated by an equals sign.
> 
> 3. Third, the name “typedef” suggests that a new type is being defined, but that’s not true. A typedef is just an alias.

### Typedefs cannot work with templates
See [this answer](https://stackoverflow.com/a/32959200) on SO for some subtle differences between them. Particularly, `using` aliases are compatible with templates whereas typedefs are not.

>The using syntax has an advantage when used within templates. If you need the type abstraction, but also need to keep template parameter to be possible to be specified in future. 

> They are essentially the same but using provides alias templates which is quite useful. One good example I could find is as follows:
> 
> ```
> namespace std {
>  template<typename T> using add_const_t = typename add_const<T>::type;
> }
> ```
> So, we can use `std::add_const_t<T>` instead of `typename std::add_const<T>::type`

Also, as per [this](https://learn.microsoft.com/en-us/cpp/cpp/aliases-and-typedefs-cpp?view=msvc-170#remarks) Microsoft docs page:

>A limitation of the typedef mechanism is that it doesn't work with templates. However, the type alias syntax in C++11 enables the creation of alias templates:
> ```
> template<typename T> using ptr = T*;
> 
> // the name 'ptr<T>' is now an alias for pointer to T
> ptr<int> ptr_int;
> ```