### PR TITLE
Partial clean up of codebase

### DIFF
--- a/cpp/examples/primal_dual/inpainting.cc
+++ b/cpp/examples/primal_dual/inpainting.cc
@@ -16,7 +16,6 @@
 #include "sopt/power_method.h"
 #include "sopt/relative_variation.h"
 #include "sopt/sampling.h"
-#include "sopt/types.h"
 #include "sopt/utilities.h"
 #include "sopt/wavelets.h"
 #include "sopt/wavelets/sara.h"

--- a/cpp/sopt/config.in.h
+++ b/cpp/sopt/config.in.h
@@ -45,6 +45,6 @@ inline constexpr bool color_logger() { return @SOPT_COLOR_LOGGING@; }
 //! Number of threads used during testing
 inline constexpr std::size_t number_of_threads_in_tests() { return @SOPT_DEFAULT_OPENMP_THREADS@; }
 # endif
-}
+} // namespace sopt
 
 #endif

--- a/cpp/sopt/cppflow_utils.h
+++ b/cpp/sopt/cppflow_utils.h
@@ -6,6 +6,7 @@
 #include <cppflow/cppflow.h>
 #include "cppflow/ops.h"
 #include <complex>
+#include <vector>
 
 namespace sopt {
 namespace cppflowutils {

--- a/cpp/sopt/credible_region.h
+++ b/cpp/sopt/credible_region.h
@@ -2,8 +2,11 @@
 #define SOPT_CREDIBLE_REGION_H
 
 #include "sopt/config.h"
+#include <algorithm> // for std::min()
 #include <functional>
 #include <iostream>
+#include <memory> // for make_shared<>
+#include <tuple> // for tuple<>
 #include <type_traits>
 #include "sopt/bisection_method.h"
 #include "sopt/exception.h"

--- a/cpp/sopt/forward_backward.h
+++ b/cpp/sopt/forward_backward.h
@@ -4,6 +4,8 @@
 #include "sopt/config.h"
 #include <functional>
 #include <limits>
+#include <tuple> // for tuple<>
+#include <utility> // for std::move<>
 #include "sopt/exception.h"
 #include "sopt/linear_transform.h"
 #include "sopt/logging.h"

--- a/cpp/sopt/imaging_forward_backward.h
+++ b/cpp/sopt/imaging_forward_backward.h
@@ -2,6 +2,8 @@
 #define SOPT_IMAGING_FORWARD_BACKWARD_H
 
 #include "sopt/config.h"
+#include <limits> // for std::numeric_limits<>
+#include <memory> // for std::shared_ptr<>
 #include <numeric>
 #include <tuple>
 #include <utility>
@@ -142,7 +144,7 @@ class ImagingForwardBackward {
   //! Vector of target measurements
   t_Vector const &target() const { return target_; }
   //! Minimun of objective_function
-  Real objmin() const { return objmin_; };
+  Real objmin() const { return objmin_; }
   //! Sets the vector of target measurements
   template <class DERIVED>
   ImagingForwardBackward<Scalar> &target(Eigen::MatrixBase<DERIVED> const &target) {
@@ -294,7 +296,7 @@ bool ImagingForwardBackward<SCALAR>::residual_convergence(t_Vector const &x,
   auto const residual_norm = sopt::l2_norm(residual);
   SOPT_LOW_LOG("    - [FB] Residuals: {} <? {}", residual_norm, residual_tolerance());
   return residual_norm < residual_tolerance();
-};
+}
 
 template <class SCALAR>
 bool ImagingForwardBackward<SCALAR>::objective_convergence(ScalarRelativeVariation<Scalar> &scalvar,
@@ -305,7 +307,7 @@ bool ImagingForwardBackward<SCALAR>::objective_convergence(ScalarRelativeVariati
   auto const current = ((gamma() > 0) ? g_proximal_->proximal_norm(x)
 			* gamma() : 0) + std::pow(sopt::l2_norm(residual), 2) / (2 * sigma() * sigma());
   return scalvar(current);
-};
+}
 
 #ifdef SOPT_MPI
 template <class SCALAR>
@@ -319,7 +321,7 @@ bool ImagingForwardBackward<SCALAR>::objective_convergence(mpi::Communicator con
 	((gamma() > 0) ? g_proximal_->proximal_norm(x)
        * gamma() : 0) + std::pow(sopt::l2_norm(residual), 2) / (2 * sigma_ * sigma_));
   return scalvar(current);
-};
+}
 #endif
 
 template <class SCALAR>

--- a/cpp/sopt/imaging_padmm.h
+++ b/cpp/sopt/imaging_padmm.h
@@ -2,6 +2,7 @@
 #define SOPT_L1_PROXIMAL_ADMM_H
 
 #include "sopt/config.h"
+#include <limits> // for std::numeric_limits<>
 #include <numeric>
 #include <tuple>
 #include <utility>
@@ -323,7 +324,7 @@ bool ImagingProximalADMM<SCALAR>::residual_convergence(t_Vector const &x,
   auto const residual_norm = sopt::l2_norm(residual, l2ball_proximal_weights());
   SOPT_LOW_LOG("    - [PADMM] Residuals: {} <? {}", residual_norm, residual_tolerance());
   return residual_norm < residual_tolerance();
-};
+}
 
 template <class SCALAR>
 bool ImagingProximalADMM<SCALAR>::objective_convergence(ScalarRelativeVariation<Scalar> &scalvar,
@@ -334,7 +335,7 @@ bool ImagingProximalADMM<SCALAR>::objective_convergence(ScalarRelativeVariation<
   auto const current =
       sopt::l1_norm(static_cast<t_Vector>(Psi().adjoint() * x), l1_proximal_weights());
   return scalvar(current);
-};
+}
 
 template <class SCALAR>
 bool ImagingProximalADMM<SCALAR>::is_converged(ScalarRelativeVariation<Scalar> &scalvar,

--- a/cpp/sopt/imaging_primal_dual.h
+++ b/cpp/sopt/imaging_primal_dual.h
@@ -2,6 +2,7 @@
 #define SOPT_L1_PRIMAL_DUAL_H
 
 #include "sopt/config.h"
+#include <limits> // for std::numeric_limits<>
 #include <numeric>
 #include <tuple>
 #include <utility>
@@ -297,7 +298,7 @@ class ImagingPrimalDual {
     no_weights(output, 1, x);
     with_weights(outputw, Vector<Real>::Ones(this->l1_proximal_weights().size()), x);
     return output.isApprox(outputw);
-  };
+  }
 };
 
 template <class SCALAR>
@@ -371,7 +372,7 @@ bool ImagingPrimalDual<SCALAR>::residual_convergence(t_Vector const &x,
   auto const residual_norm = sopt::l2_norm(residual, l2ball_proximal_weights());
   SOPT_LOW_LOG("    - [Primal Dual] Residuals: {} <? {}", residual_norm, residual_tolerance());
   return residual_norm < residual_tolerance();
-};
+}
 
 template <class SCALAR>
 bool ImagingPrimalDual<SCALAR>::objective_convergence(ScalarRelativeVariation<Scalar> &scalvar,
@@ -382,7 +383,7 @@ bool ImagingPrimalDual<SCALAR>::objective_convergence(ScalarRelativeVariation<Sc
   auto const current =
       sopt::l1_norm(static_cast<t_Vector>(Psi().adjoint() * x), l1_proximal_weights());
   return scalvar(current);
-};
+}
 
 template <class SCALAR>
 bool ImagingPrimalDual<SCALAR>::is_converged(ScalarRelativeVariation<Scalar> &scalvar,

--- a/cpp/sopt/joint_map.h
+++ b/cpp/sopt/joint_map.h
@@ -4,6 +4,8 @@
 #include "sopt/config.h"
 #include <functional>
 #include <limits>
+#include <memory> // for std::shared_ptr<>
+#include <utility> // for std::forward<>
 #include "sopt/exception.h"
 #include "sopt/forward_backward.h"
 #include "sopt/imaging_forward_backward.h"
@@ -43,7 +45,7 @@ class JointMAP {
         is_converged_([](t_Vector const &, t_Vector const &, t_real const) { return true; }),
         relative_variation_(1e-3),
         objective_variation_(1e-3),
-        itermax_(std::numeric_limits<t_uint>::max()){};
+        itermax_(std::numeric_limits<t_uint>::max()){}
 
 #define SOPT_MACRO(NAME, TYPE)                  \
   TYPE const &NAME() const { return NAME##_; }  \
@@ -132,7 +134,7 @@ class JointMAP {
     diagnostic.reg_niters = niters;
     diagnostic.reg_term = gamma;
     return diagnostic;
-  };
+  }
 };
 
 }  // namespace algorithm

--- a/cpp/sopt/l1_g_proximal.h
+++ b/cpp/sopt/l1_g_proximal.h
@@ -42,7 +42,7 @@ public:
   L1GProximal(bool tight_frame = false)
     : tight_frame_ (tight_frame),
       l1_proximal_() {}
-  ~L1GProximal() {};
+  ~L1GProximal() {}
 
 // Implements the interface in GProximal
 

--- a/cpp/sopt/l1_proximal.h
+++ b/cpp/sopt/l1_proximal.h
@@ -4,6 +4,7 @@
 #include "sopt/config.h"
 #include <array>
 #include <type_traits>
+#include <utility> // for std::forward<>
 #include <Eigen/Core>
 #include "sopt/linear_transform.h"
 #include "sopt/maths.h"
@@ -392,7 +393,7 @@ template <class SCALAR>
 class L1<SCALAR>::FistaMixing {
  public:
   typedef typename real_type<SCALAR>::type Real;
-  FistaMixing() : t(1){};
+  FistaMixing() : t(1){}
   template <class T1>
   void operator()(Vector<SCALAR> &previous, Eigen::MatrixBase<T1> const &unmixed, t_uint iter) {
     // reset

--- a/cpp/sopt/l2_forward_backward.h
+++ b/cpp/sopt/l2_forward_backward.h
@@ -2,6 +2,7 @@
 #define SOPT_L2_FORWARD_BACKWARD_H
 
 #include "sopt/config.h"
+#include <limits> // for std::numeric_limits<>
 #include <numeric>
 #include <tuple>
 #include <utility>
@@ -138,7 +139,7 @@ class L2ForwardBackward {
   //! Vector of target measurements
   t_Vector const &target() const { return target_; }
   //! Minimun of objective_function
-  Real objmin() const { return objmin_; };
+  Real objmin() const { return objmin_; }
   //! Sets the vector of target measurements
   template <class DERIVED>
   L2ForwardBackward<Scalar> &target(Eigen::MatrixBase<DERIVED> const &target) {
@@ -294,7 +295,7 @@ bool L2ForwardBackward<SCALAR>::residual_convergence(t_Vector const &x,
   auto const residual_norm = sopt::l2_norm(residual);
   SOPT_LOW_LOG("    - [FB] Residuals: {} <? {}", residual_norm, residual_tolerance());
   return residual_norm < residual_tolerance();
-};
+}
 
 template <class SCALAR>
 bool L2ForwardBackward<SCALAR>::objective_convergence(ScalarRelativeVariation<Scalar> &scalvar,
@@ -305,7 +306,7 @@ bool L2ForwardBackward<SCALAR>::objective_convergence(ScalarRelativeVariation<Sc
   auto const current = ((gamma() > 0) ? sopt::l2_norm(x, l2_proximal_weights()) * gamma() : 0) +
                        std::pow(sopt::l2_norm(residual), 2) / (2 * sigma() * sigma());
   return scalvar(current);
-};
+}
 
 #ifdef SOPT_MPI
 template <class SCALAR>
@@ -319,7 +320,7 @@ bool L2ForwardBackward<SCALAR>::objective_convergence(mpi::Communicator const &o
       ((gamma() > 0) ? sopt::l2_norm(x, l2_proximal_weights()) * gamma() : 0) +
       std::pow(sopt::l2_norm(residual), 2) / (2 * sigma() * sigma()));
   return scalvar(current);
-};
+}
 #endif
 
 template <class SCALAR>

--- a/cpp/sopt/l2_primal_dual.h
+++ b/cpp/sopt/l2_primal_dual.h
@@ -2,6 +2,7 @@
 #define SOPT_L2_PRIMAL_DUAL_H
 
 #include "sopt/config.h"
+#include <limits>  // for std::numeric_limits<>
 #include <numeric>
 #include <tuple>
 #include <utility>
@@ -296,7 +297,7 @@ class ImagingPrimalDual {
     no_weights(output, 1, x);
     with_weights(outputw, Vector<Real>::Ones(1), x);
     return output.isApprox(outputw);
-  };
+  }
 };
 
 template <class SCALAR>
@@ -370,7 +371,7 @@ bool ImagingPrimalDual<SCALAR>::residual_convergence(t_Vector const &x,
   auto const residual_norm = sopt::l2_norm(residual, l2ball_proximal_weights());
   SOPT_LOW_LOG("    - [Primal Dual] Residuals: {} <? {}", residual_norm, residual_tolerance());
   return residual_norm < residual_tolerance();
-};
+}
 
 template <class SCALAR>
 bool ImagingPrimalDual<SCALAR>::objective_convergence(ScalarRelativeVariation<Scalar> &scalvar,
@@ -383,7 +384,7 @@ bool ImagingPrimalDual<SCALAR>::objective_convergence(ScalarRelativeVariation<Sc
           ? sopt::l2_norm(l2_proximal_weights().array() * (Psi().adjoint() * x).array())
           : sopt::l2_norm(l2_proximal_weights()(0) * (Psi().adjoint() * x));
   return scalvar(current);
-};
+}
 
 template <class SCALAR>
 bool ImagingPrimalDual<SCALAR>::is_converged(ScalarRelativeVariation<Scalar> &scalvar,

--- a/cpp/sopt/linear_transform.h
+++ b/cpp/sopt/linear_transform.h
@@ -5,6 +5,7 @@
 #include <array>
 #include <memory>
 #include <type_traits>
+#include <utility>  // for std::move<>
 #include <Eigen/Core>
 #include "sopt/logging.h"
 #include "sopt/maths.h"
@@ -152,7 +153,7 @@ class MatrixToLinearTransform {
   template <class T0>
   MatrixToLinearTransform(Eigen::MatrixBase<T0> const &A) : matrix(std::make_shared<EIGEN>(A)) {}
   //! Creates from a shared matrix.
-  MatrixToLinearTransform(std::shared_ptr<EIGEN> const &x) : matrix(x){};
+  MatrixToLinearTransform(std::shared_ptr<EIGEN> const &x) : matrix(x){}
 
   //! Performs operation
   void operator()(PlainObject &out, PlainObject const &x) const {
@@ -185,7 +186,7 @@ class MatrixAdjointToLinearTransform {
   MatrixAdjointToLinearTransform(Eigen::MatrixBase<T0> const &A)
       : matrix(std::make_shared<EIGEN>(A)) {}
   //! Creates from a shared matrix.
-  MatrixAdjointToLinearTransform(std::shared_ptr<EIGEN> const &x) : matrix(x){};
+  MatrixAdjointToLinearTransform(std::shared_ptr<EIGEN> const &x) : matrix(x){}
 
   //! Performs operation
   void operator()(PlainObject &out, PlainObject const &x) const {

--- a/cpp/sopt/logging.disabled.h
+++ b/cpp/sopt/logging.disabled.h
@@ -14,8 +14,8 @@ inline std::shared_ptr<int> initialize(std::string const &) { return nullptr; }
 inline std::shared_ptr<int> initialize() { return nullptr; }
 inline std::shared_ptr<int> get(std::string const &) { return nullptr; }
 inline std::shared_ptr<int> get() { return nullptr; }
-inline void set_level(std::string const &, std::string const &){};
-inline void set_level(std::string const &){};
+inline void set_level(std::string const &, std::string const &){}
+inline void set_level(std::string const &){}
 inline bool has_level(std::string const &, std::string const &) { return false; }
 }  // namespace logging
 }  // namespace sopt

--- a/cpp/sopt/logging.enabled.h
+++ b/cpp/sopt/logging.enabled.h
@@ -2,6 +2,8 @@
 #define SOPT_LOGGING_ENABLED_H
 
 #include "sopt/config.h"
+#include <memory> // for std::shared_ptr<>
+#include <string> // for std::string
 #include <spdlog/fmt/ostr.h>
 #include <spdlog/spdlog.h>
 #include <spdlog/sinks/stdout_sinks.h>

--- a/cpp/sopt/mpi/communicator.h
+++ b/cpp/sopt/mpi/communicator.h
@@ -6,6 +6,7 @@
 
 #ifdef SOPT_MPI
 
+#include <algorithm> // for std::copy
 #include <iostream>
 #include <memory>
 #include <mpi.h>
@@ -47,7 +48,7 @@ class Communicator {
   static Communicator World() { return Communicator(MPI_COMM_WORLD); }
   static Communicator Self() { return Communicator(MPI_COMM_SELF); }
 
-  virtual ~Communicator(){};
+  virtual ~Communicator(){}
 
   //! The number of processes
   decltype(Impl::size) size() const { return impl ? impl->size : 1; }
@@ -342,7 +343,7 @@ Communicator::all_to_allv(const std::vector<T> &vec, std::vector<t_int> const &s
   }
 
   return all_to_allv<T>(vec, send_sizes, rec_sizes);
-};
+}
 template <class T>
 typename std::enable_if<is_registered_type<T>::value, std::vector<T>>::type
 Communicator::all_to_allv(const std::vector<T> &vec, std::vector<t_int> const &send_sizes,
@@ -372,7 +373,7 @@ Communicator::all_to_allv(const std::vector<T> &vec, std::vector<t_int> const &s
                 sdispls.data(), registered_type(T(0)), output.data(), rsizes_.data(),
                 rdispls.data(), registered_type(T(0)), **this);
   return output;
-};
+}
 
 template <class T>
 typename std::enable_if<is_registered_type<T>::value, Vector<T>>::type Communicator::all_to_allv(
@@ -391,7 +392,7 @@ typename std::enable_if<is_registered_type<T>::value, Vector<T>>::type Communica
   }
 
   return all_to_allv<T>(vec, send_sizes, rec_sizes);
-};
+}
 
 template <class T>
 typename std::enable_if<is_registered_type<T>::value, Vector<T>>::type Communicator::all_to_allv(
@@ -422,7 +423,7 @@ typename std::enable_if<is_registered_type<T>::value, Vector<T>>::type Communica
                 sdispls.data(), registered_type(T(0)), output.data(), rsizes_.data(),
                 rdispls.data(), registered_type(T(0)), **this);
   return output;
-};
+}
 
 template <class T>
 typename std::enable_if<is_registered_type<T>::value, std::vector<T>>::type Communicator::gather(

--- a/cpp/sopt/padmm.h
+++ b/cpp/sopt/padmm.h
@@ -4,6 +4,8 @@
 #include "sopt/config.h"
 #include <functional>
 #include <limits>
+#include <tuple> // for std::tuple<>
+#include <utility> // for std::move<>
 #include "sopt/exception.h"
 #include "sopt/linear_transform.h"
 #include "sopt/logging.h"

--- a/cpp/sopt/positive_quadrant.h
+++ b/cpp/sopt/positive_quadrant.h
@@ -4,6 +4,8 @@
 #include "sopt/linear_transform.h"
 #include "sopt/types.h"
 
+#include <utility> // for std::forward
+
 namespace sopt {
 namespace algorithm {
 //! \brief Computes according to given algorithm and then projects it to the positive quadrant

--- a/cpp/sopt/power_method.h
+++ b/cpp/sopt/power_method.h
@@ -4,7 +4,9 @@
 #include "sopt/config.h"
 #include <functional>
 #include <limits>
+#include <memory> // for std::shared_ptr<>
 #include <tuple>
+#include <utility> // for std::move<>
 #include "sopt/exception.h"
 #include "sopt/linear_transform.h"
 #include "sopt/logging.h"

--- a/cpp/sopt/primal_dual.h
+++ b/cpp/sopt/primal_dual.h
@@ -4,6 +4,8 @@
 #include "sopt/config.h"
 #include <functional>
 #include <limits>
+#include <tuple> // for std::tuple<>
+#include <utility> // for std::move<>
 #include "sopt/exception.h"
 #include "sopt/linear_transform.h"
 #include "sopt/logging.h"

--- a/cpp/sopt/proximal_expression.h
+++ b/cpp/sopt/proximal_expression.h
@@ -3,6 +3,7 @@
 
 #include "sopt/config.h"
 #include <type_traits>
+#include <utility> // for std::move<>
 #include <Eigen/Core>
 #include "sopt/maths.h"
 

--- a/cpp/sopt/reweighted.h
+++ b/cpp/sopt/reweighted.h
@@ -4,6 +4,10 @@
 #include "sopt/linear_transform.h"
 #include "sopt/types.h"
 
+#include <algorithm> // for std::max<>
+#include <limits>  // for std::numeric_limits<>
+#include <utility> // for std::move<>
+
 namespace sopt {
 namespace algorithm {
 template <class ALGORITHM>

--- a/cpp/sopt/sampling.h
+++ b/cpp/sopt/sampling.h
@@ -5,6 +5,7 @@
 #include <initializer_list>
 #include <memory>
 #include <random>
+#include <vector> // for std::vector<>
 #include <Eigen/Core>
 #include "sopt/linear_transform.h"
 #include "sopt/types.h"

--- a/cpp/sopt/sdmm.h
+++ b/cpp/sopt/sdmm.h
@@ -4,6 +4,7 @@
 #include "sopt/config.h"
 #include <limits>
 #include <numeric>
+#include <utility> // for std::forward<>
 #include <vector>
 #include "sopt/conjugate_gradient.h"
 #include "sopt/exception.h"

--- a/cpp/sopt/tf_g_proximal.h
+++ b/cpp/sopt/tf_g_proximal.h
@@ -3,6 +3,7 @@
 // TODO: Clean up unnecessary includes
 #include "sopt/config.h"
 #include <numeric>
+#include <string> // for std::string
 #include <tuple>
 #include <utility>
 #include "sopt/exception.h"
@@ -105,7 +106,7 @@ protected:
     // Added template keyword to suppress error on apple-clang, for reference
     // https://stackoverflow.com/questions/3786360/confusing-template-error
     auto output_vector = model_output[0].template get_data<float>();
-    
+
     for(int i = 0; i < image_size; i++) {
       image_out[i] = static_cast<Scalar>(output_vector[i]);
     }

--- a/cpp/sopt/tv_primal_dual.h
+++ b/cpp/sopt/tv_primal_dual.h
@@ -2,6 +2,7 @@
 #define SOPT_TV_PRIMAL_DUAL_H
 
 #include "sopt/config.h"
+#include <limits>  // for std::numeric_limits<>
 #include <numeric>
 #include <tuple>
 #include <utility>

--- a/cpp/sopt/utilities.h
+++ b/cpp/sopt/utilities.h
@@ -2,6 +2,7 @@
 #define SOPT_UTILITIES_H
 
 #include "sopt/config.h"
+#include <string> // for std::string
 #include <Eigen/Core>
 #include "sopt/types.h"
 

--- a/cpp/sopt/wavelets/direct.h
+++ b/cpp/sopt/wavelets/direct.h
@@ -2,6 +2,7 @@
 #define SOPT_WAVELETS_DIRECT_H
 
 #include "sopt/config.h"
+#include <algorithm> // for std::copy<>
 #include <type_traits>
 #include "sopt/types.h"
 #include "sopt/wavelets/wavelet_data.h"

--- a/cpp/sopt/wavelets/indirect.h
+++ b/cpp/sopt/wavelets/indirect.h
@@ -6,6 +6,8 @@
 #include "sopt/wavelets/innards.impl.h"
 #include "sopt/wavelets/wavelet_data.h"
 
+#include <algorithm> // for std::copy<>
+
 // Function inside anonymouns namespace won't appear in library
 namespace sopt {
 namespace wavelets {

--- a/cpp/sopt/wavelets/innards.impl.h
+++ b/cpp/sopt/wavelets/innards.impl.h
@@ -2,6 +2,7 @@
 #define SOPT_WAVELETS_INNARDS_H
 
 #include "sopt/config.h"
+#include <algorithm> // for std::copy<>
 #include <Eigen/Core>
 
 // Function inside anonymouns namespace won't appear in library

--- a/cpp/sopt/wavelets/sara.h
+++ b/cpp/sopt/wavelets/sara.h
@@ -2,8 +2,10 @@
 #define SOPT_WAVELETS_SARA_H
 
 #include "sopt/config.h"
+#include <algorithm> // for std::min<>
 #include <cmath>
 #include <initializer_list>
+#include <string> // for std::string
 #include <tuple>
 #include <vector>
 #include "sopt/logging.h"

--- a/cpp/sopt/wavelets/wavelets.h
+++ b/cpp/sopt/wavelets/wavelets.h
@@ -7,6 +7,8 @@
 #include "sopt/wavelets/indirect.h"
 #include "sopt/wavelets/wavelet_data.h"
 
+#include <string> // for std::string
+
 namespace sopt {
 namespace wavelets {
 

--- a/cpp/sopt/wrapper.h
+++ b/cpp/sopt/wrapper.h
@@ -3,6 +3,7 @@
 
 #include <array>
 #include <type_traits>
+#include <utility> // for std::move<>
 
 #include "sopt/config.h"
 #include "sopt/exception.h"

--- a/cpp/tools_for_tests/tiffwrappers.h
+++ b/cpp/tools_for_tests/tiffwrappers.h
@@ -2,6 +2,7 @@
 #define SOPT_TIFF_WRAPPER_H
 
 #include "sopt/config.h"
+#include <string> // for std::string
 #include <Eigen/Core>
 #include "sopt/types.h"
 


### PR DESCRIPTION
Clean up incorporates (amid others) the following:
- removes duplicate header includes
- adds missing header includes
- adds closing namespace comments
- removes unnecessary semicolons (null statements)