### PR TITLE
Replace postfix increment and decrement operators with their prefix equivalents

### DIFF
--- a/cpp/examples/forward_backward/inpainting.cc
+++ b/cpp/examples/forward_backward/inpainting.cc
@@ -80,7 +80,7 @@ int main(int argc, char const **argv) {
   SOPT_HIGH_LOG("Create dirty vector");
   std::normal_distribution<> gaussian_dist(0, sigma);
   Vector y(y0.size());
-  for (sopt::t_int i = 0; i < y0.size(); i++) y(i) = y0(i) + gaussian_dist(mersenne);
+  for (sopt::t_int i = 0; i < y0.size(); ++i) y(i) = y0(i) + gaussian_dist(mersenne);
   // Write dirty imagte to file
   if (output != "none") {
     Vector const dirty = sampling.adjoint() * y;

--- a/cpp/examples/forward_backward/inpainting_credible_interval.cc
+++ b/cpp/examples/forward_backward/inpainting_credible_interval.cc
@@ -82,7 +82,7 @@ int main(int argc, char const **argv) {
   SOPT_HIGH_LOG("Create dirty vector");
   std::normal_distribution<> gaussian_dist(0, sigma);
   Vector y(y0.size());
-  for (sopt::t_int i = 0; i < y0.size(); i++) y(i) = y0(i) + gaussian_dist(mersenne);
+  for (sopt::t_int i = 0; i < y0.size(); ++i) y(i) = y0(i) + gaussian_dist(mersenne);
   // Write dirty imagte to file
   if (output != "none") {
     Vector const dirty = sampling.adjoint() * y;

--- a/cpp/examples/forward_backward/inpainting_joint_map.cc
+++ b/cpp/examples/forward_backward/inpainting_joint_map.cc
@@ -81,7 +81,7 @@ int main(int argc, char const **argv) {
   SOPT_HIGH_LOG("Create dirty vector");
   std::normal_distribution<> gaussian_dist(0, sigma);
   Vector y(y0.size());
-  for (sopt::t_int i = 0; i < y0.size(); i++) y(i) = y0(i) + gaussian_dist(mersenne);
+  for (sopt::t_int i = 0; i < y0.size(); ++i) y(i) = y0(i) + gaussian_dist(mersenne);
   // Write dirty imagte to file
   if (output != "none") {
     Vector const dirty = sampling.adjoint() * y;

--- a/cpp/examples/forward_backward/l2_inpainting.cc
+++ b/cpp/examples/forward_backward/l2_inpainting.cc
@@ -78,7 +78,7 @@ int main(int argc, char const **argv) {
   SOPT_HIGH_LOG("Create dirty vector");
   std::normal_distribution<> gaussian_dist(0, sigma);
   Vector y(y0.size());
-  for (sopt::t_int i = 0; i < y0.size(); i++) y(i) = y0(i) + gaussian_dist(mersenne);
+  for (sopt::t_int i = 0; i < y0.size(); ++i) y(i) = y0(i) + gaussian_dist(mersenne);
   // Write dirty imagte to file
   if (output != "none") {
     Vector const dirty = sampling.adjoint() * y;

--- a/cpp/examples/primal_dual/inpainting.cc
+++ b/cpp/examples/primal_dual/inpainting.cc
@@ -89,7 +89,7 @@ int main(int argc, char const **argv) {
   SOPT_HIGH_LOG("Create dirty vector");
   std::normal_distribution<> gaussian_dist(0, sigma);
   Vector y(y0.size());
-  for (sopt::t_int i = 0; i < y0.size(); i++) y(i) = y0(i) + gaussian_dist(mersenne);
+  for (sopt::t_int i = 0; i < y0.size(); ++i) y(i) = y0(i) + gaussian_dist(mersenne);
   // Write dirty image to file
   if (output != "none") {
     Vector const dirty = sampling.adjoint() * y;

--- a/cpp/examples/primal_dual/tv_inpainting.cc
+++ b/cpp/examples/primal_dual/tv_inpainting.cc
@@ -82,7 +82,7 @@ int main(int argc, char const **argv) {
   SOPT_HIGH_LOG("Create dirty vector");
   std::normal_distribution<> gaussian_dist(0, sigma);
   Vector y(y0.size());
-  for (sopt::t_int i = 0; i < y0.size(); i++) y(i) = y0(i) + gaussian_dist(mersenne);
+  for (sopt::t_int i = 0; i < y0.size(); ++i) y(i) = y0(i) + gaussian_dist(mersenne);
   // Write dirty image to file
   if (output != "none") {
     Vector const dirty = sampling.adjoint() * y;

--- a/cpp/examples/proximal_admm/inpainting.cc
+++ b/cpp/examples/proximal_admm/inpainting.cc
@@ -75,7 +75,7 @@ int main(int argc, char const **argv) {
   SOPT_HIGH_LOG("Create dirty vector");
   std::normal_distribution<> gaussian_dist(0, sigma);
   Vector y(y0.size());
-  for (sopt::t_int i = 0; i < y0.size(); i++) y(i) = y0(i) + gaussian_dist(mersenne);
+  for (sopt::t_int i = 0; i < y0.size(); ++i) y(i) = y0(i) + gaussian_dist(mersenne);
   // Write dirty imagte to file
   if (output != "none") {
     Vector const dirty = sampling.adjoint() * y;

--- a/cpp/examples/proximal_admm/reweighted.cc
+++ b/cpp/examples/proximal_admm/reweighted.cc
@@ -79,7 +79,7 @@ int main(int argc, char const **argv) {
   SOPT_MEDIUM_LOG("Create dirty vector");
   std::normal_distribution<> gaussian_dist(0, sigma);
   Vector y(y0.size());
-  for (sopt::t_int i = 0; i < y0.size(); i++) y(i) = y0(i) + gaussian_dist(mersenne);
+  for (sopt::t_int i = 0; i < y0.size(); ++i) y(i) = y0(i) + gaussian_dist(mersenne);
   // Write dirty imagte to file
   if (output != "none") {
     Vector const dirty = sampling.adjoint() * y;

--- a/cpp/examples/sdmm/inpainting.cc
+++ b/cpp/examples/sdmm/inpainting.cc
@@ -74,7 +74,7 @@ int main(int argc, char const **argv) {
   SOPT_HIGH_LOG("Create dirty vector");
   std::normal_distribution<> gaussian_dist(0, sigma);
   Vector y(y0.size());
-  for (sopt::t_int i = 0; i < y0.size(); i++) y(i) = y0(i) + gaussian_dist(mersenne);
+  for (sopt::t_int i = 0; i < y0.size(); ++i) y(i) = y0(i) + gaussian_dist(mersenne);
   // Write dirty imagte to file
   if (output != "none") {
     Vector const dirty = sampling.adjoint() * y;

--- a/cpp/examples/sdmm/reweighted.cc
+++ b/cpp/examples/sdmm/reweighted.cc
@@ -78,7 +78,7 @@ int main(int argc, char const **argv) {
   SOPT_HIGH_LOG("Create dirty vector");
   std::normal_distribution<> gaussian_dist(0, sigma);
   Vector y(y0.size());
-  for (sopt::t_int i = 0; i < y0.size(); i++) y(i) = y0(i) + gaussian_dist(mersenne);
+  for (sopt::t_int i = 0; i < y0.size(); ++i) y(i) = y0(i) + gaussian_dist(mersenne);
   // Write dirty imagte to file
   if (output != "none") {
     Vector const dirty = sampling.adjoint() * y;

--- a/cpp/sopt/chained_operators.h
+++ b/cpp/sopt/chained_operators.h
@@ -23,12 +23,12 @@ OperatorFunction<T0> chained_operators(OperatorFunction<T0> const &arg0, T const
       (*first)(output, input);
     else {
       (*first)(*buffer, input);
-      first++;
+      ++first;
       (*first)(output, *buffer);
     }
-    for (++first; first != last; first++) {
+    for (++first; first != last; ++first) {
       (*first)(*buffer, output);
-      first++;
+      ++first;
       (*first)(output, *buffer);
     }
   };

--- a/cpp/sopt/cppflow_utils.cc
+++ b/cpp/sopt/cppflow_utils.cc
@@ -70,7 +70,7 @@ namespace cppflowutils {
   cppflow::tensor convert_image_to_tensor(sopt::Vector<std::complex<double>> const &image, int image_rows, int image_cols) {
 
     std::vector<float> input_values(image_rows);
-    for(int i = 0; i < image_rows; i++)
+    for(int i = 0; i < image_rows; ++i)
     {
       if(std::abs(image(i).real()) > cppflowutils::imaginary_threshold)
       {

--- a/cpp/sopt/credible_region.h
+++ b/cpp/sopt/credible_region.h
@@ -145,8 +145,8 @@ credible_interval_grid(const Eigen::MatrixBase<T> &solution, const t_uint &rows,
   Image<K> credible_grid_upper_bound = Image<K>::Zero(grid_rows, grid_cols);
   Image<K> credible_grid_mean = Image<K>::Zero(grid_rows, grid_cols);
   SOPT_LOW_LOG("Starting calculation of credible interval: {} x {} grid.", grid_rows, grid_cols);
-  for (t_uint i = 0; i < grid_rows; i++) {
-    for (t_uint j = 0; j < grid_cols; j++) {
+  for (t_uint i = 0; i < grid_rows; ++i) {
+    for (t_uint j = 0; j < grid_cols; ++j) {
       const t_uint start_row = i * drow;
       const t_uint start_col = j * dcol;
       if (static_cast<t_int>(rows - start_row - drow) < 0)

--- a/cpp/sopt/gradient_operator.h
+++ b/cpp/sopt/gradient_operator.h
@@ -28,9 +28,9 @@ template <class T>
 Vector<T> diff2d(const Vector<T> &x, const t_int rows, const t_int cols) {
   Matrix<T> output = Matrix<T>::Zero(rows, 2 * cols);
   const Matrix<T> &input_image = Matrix<T>::Map(x.data(), rows, cols);
-  for (Eigen::Index i(0); i < rows; i++)
+  for (Eigen::Index i(0); i < rows; ++i)
     output.block(0, 0, rows, cols).row(i) = diff<T>(input_image.row(i));
-  for (Eigen::Index i(0); i < cols; i++)
+  for (Eigen::Index i(0); i < cols; ++i)
     output.block(0, cols, rows, cols).col(i) = diff<T>(input_image.col(i));
   return Vector<T>::Map(output.data(), output.size());
 }
@@ -39,9 +39,9 @@ template <class T>
 Vector<T> diff2d_adjoint(const Vector<T> &x, const t_int rows, const t_int cols) {
   const Matrix<T> &input_image = Matrix<T>::Map(x.data(), rows, 2 * cols);
   Matrix<T> output = Matrix<T>::Zero(rows, cols);
-  for (Eigen::Index i(0); i < rows; i++)
+  for (Eigen::Index i(0); i < rows; ++i)
     output.row(i) += diff_adjoint<T>(input_image.block(0, 0, rows, cols).row(i));
-  for (Eigen::Index i(0); i < cols; i++)
+  for (Eigen::Index i(0); i < cols; ++i)
     output.col(i) += diff_adjoint<T>(input_image.block(0, cols, rows, cols).col(i));
   return Vector<T>::Map(output.data(), output.size());
 }

--- a/cpp/sopt/imaging_primal_dual.h
+++ b/cpp/sopt/imaging_primal_dual.h
@@ -318,7 +318,7 @@ typename ImagingPrimalDual<SCALAR>::Diagnostic ImagingPrimalDual<SCALAR>::operat
   auto const g_proximal = [this](t_Vector &out, Real gamma, t_Vector const &x) {
     this->l2ball_proximal()(out, gamma, x);
     // applying preconditioning
-    for (t_int i = 0; i < this->precondition_iters(); i++)
+    for (t_int i = 0; i < this->precondition_iters(); ++i)
       this->l2ball_proximal()(
           out, gamma,
           out - this->precondition_stepsize() *

--- a/cpp/sopt/joint_map.h
+++ b/cpp/sopt/joint_map.h
@@ -104,7 +104,7 @@ class JointMAP {
     typedef typename ALGORITHM::DiagnosticAndResult ResultType;
     ResultType result = (*(this->algo_ptr_))(std::forward<ARGS>(args)...);
     t_real gamma = 0;
-    niters++;
+    ++niters;
     t_uint algo_iters(result.niters);
     for (; (not converged) && (niters < itermax()); ++niters) {
       SOPT_LOW_LOG("    - [JMAP] Iteration {}/{}", niters, itermax());

--- a/cpp/sopt/l2_primal_dual.h
+++ b/cpp/sopt/l2_primal_dual.h
@@ -317,7 +317,7 @@ typename ImagingPrimalDual<SCALAR>::Diagnostic ImagingPrimalDual<SCALAR>::operat
   auto const g_proximal = [this](t_Vector &out, Real gamma, t_Vector const &x) {
     this->l2ball_proximal()(out, gamma, x);
     // applying preconditioning
-    for (t_int i = 0; i < this->precondition_iters(); i++)
+    for (t_int i = 0; i < this->precondition_iters(); ++i)
       this->l2ball_proximal()(
           out, gamma,
           out - this->precondition_stepsize() *

--- a/cpp/sopt/mpi/communicator.h
+++ b/cpp/sopt/mpi/communicator.h
@@ -334,7 +334,7 @@ Communicator::all_to_allv(const std::vector<T> &vec, std::vector<t_int> const &s
     return vec;
   }
   std::vector<t_int> rec_sizes(send_sizes.size(), 0);
-  for (t_int i = 0; i < size(); i++) {
+  for (t_int i = 0; i < size(); ++i) {
     if (i == rank())
       rec_sizes = gather<t_int>(send_sizes[i], i);
     else
@@ -383,7 +383,7 @@ typename std::enable_if<is_registered_type<T>::value, Vector<T>>::type Communica
     return vec;
   }
   std::vector<t_int> rec_sizes(send_sizes.size(), 0);
-  for (t_int i = 0; i < size(); i++) {
+  for (t_int i = 0; i < size(); ++i) {
     if (i == rank())
       rec_sizes = gather<t_int>(send_sizes[i], i);
     else

--- a/cpp/sopt/proximal.h
+++ b/cpp/sopt/proximal.h
@@ -101,7 +101,7 @@ void tv_norm(Eigen::DenseBase<T0> &out, typename real_type<typename T0::Scalar>:
   typename T1::PlainObject const &u = x.segment(0, size);
   typename T1::PlainObject const &v = x.segment(size, size);
   out = T0::Zero(size * 2);
-  for (typename Eigen::Index i(0); i < size; i++) {
+  for (typename Eigen::Index i(0); i < size; ++i) {
     const t_real norm = std::sqrt(std::abs(u(i) * u(i) + v(i) * v(i)));
     if (norm > gamma) {
       out(i) = (1 - gamma / norm) * u(i);
@@ -119,7 +119,7 @@ void tv_norm(Eigen::DenseBase<T0> &out, Eigen::DenseBase<T2> const &gamma,
   typename T1::PlainObject const &u = x.segment(0, size);
   typename T1::PlainObject const &v = x.segment(size, size);
   out = T0::Zero(size * 2);
-  for (typename Eigen::Index i(0); i < size; i++) {
+  for (typename Eigen::Index i(0); i < size; ++i) {
     const t_real norm = std::sqrt(std::abs(u(i) * u(i) + v(i) * v(i)));
     if (norm > gamma(i)) {
       out(i) = (1 - gamma(i) / norm) * u(i);

--- a/cpp/sopt/sdmm.h
+++ b/cpp/sopt/sdmm.h
@@ -275,7 +275,7 @@ void SDMM<SCALAR>::update_directions(t_Vectors &y, t_Vectors &z, t_Vector const 
 template <class SCALAR>
 void SDMM<SCALAR>::initialization(t_Vectors &y, t_Vectors &z, t_Vector const &x) const {
   SOPT_TRACE("Initializing SDMM");
-  for (t_uint i(0); i < transforms().size(); i++) {
+  for (t_uint i(0); i < transforms().size(); ++i) {
     y[i] = transforms(i) * x;
     z[i].resize(y[i].size());
     z[i].fill(0);

--- a/cpp/sopt/tf_g_proximal.h
+++ b/cpp/sopt/tf_g_proximal.h
@@ -106,7 +106,7 @@ protected:
     // https://stackoverflow.com/questions/3786360/confusing-template-error
     auto output_vector = model_output[0].template get_data<float>();
     
-    for(int i = 0; i < image_size; i++) {
+    for(int i = 0; i < image_size; ++i) {
       image_out[i] = static_cast<Scalar>(output_vector[i]);
     }
   }

--- a/cpp/sopt/tv_primal_dual.h
+++ b/cpp/sopt/tv_primal_dual.h
@@ -316,7 +316,7 @@ typename TVPrimalDual<SCALAR>::Diagnostic TVPrimalDual<SCALAR>::operator()(
   auto const g_proximal = [this](t_Vector &out, Real gamma, t_Vector const &x) {
     this->l2ball_proximal()(out, gamma, x);
     // applying preconditioning
-    for (t_int i = 0; i < this->precondition_iters(); i++)
+    for (t_int i = 0; i < this->precondition_iters(); ++i)
       this->l2ball_proximal()(
           out, gamma,
           out - this->precondition_stepsize() *

--- a/cpp/sopt/wavelets/innards.impl.h
+++ b/cpp/sopt/wavelets/innards.impl.h
@@ -128,7 +128,7 @@ void up_convolve_sum(Eigen::ArrayBase<T0> &result, Eigen::ArrayBase<T1> const &c
 #ifdef SOPT_OPENMP
 #pragma omp parallel for
 #endif
-  for (typename T0::Index i = 0; i < result.size() / 2; i++) {
+  for (typename T0::Index i = 0; i < result.size() / 2; ++i) {
     result(2 * i + index_place_even) =
         periodic_scalar_product(coeffs.head(Nlow), low_even, i + even_offset) +
         periodic_scalar_product(coeffs.tail(Nhigh), high_even, i + even_offset);

--- a/cpp/tests/communicator.cc
+++ b/cpp/tests/communicator.cc
@@ -60,7 +60,7 @@ TEST_CASE("Creates an mpi communicator") {
       auto const result = world.scatter_one(scattered);
       REQUIRE(result == world.rank() + 2);
       auto const gathered = world.gather(result);
-      for (decltype(gathered)::size_type i = 0; i < gathered.size(); i++)
+      for (decltype(gathered)::size_type i = 0; i < gathered.size(); ++i)
         CHECK(gathered[i] == scattered[i]);
     } else {
       auto const result = world.scatter_one<t_int>();
@@ -160,7 +160,7 @@ TEST_CASE("Creates an mpi communicator") {
           Vector<t_int>::Constant(std::accumulate(sizes.begin(), sizes.end(), 0), world.rank());
       const Vector<t_int> output = world.all_to_allv(sendee, sizes);
       t_int sum = 0;
-      for (t_int i = 0; i < world.size() - 1; i++) {
+      for (t_int i = 0; i < world.size() - 1; ++i) {
         const Vector<t_int> expected = Vector<t_int>::Constant(i + 1, i + 1);
         CAPTURE(sum);
         CAPTURE(i);

--- a/cpp/tests/credible_region.cc
+++ b/cpp/tests/credible_region.cc
@@ -19,7 +19,7 @@ TEST_CASE("calculating gamma") {
   };
   const t_Vector x = t_Vector::Random(N);
   CHECK(0 == energy_function(x));
-  for (t_uint i = 1; i < 10; i++) {
+  for (t_uint i = 1; i < 10; ++i) {
     const t_real alpha = 0.9 + i * 0.01;
     const t_real gamma = credible_region::compute_energy_upper_bound(alpha, x, energy_function);
     CHECK(gamma == Approx(N * (std::sqrt(16 * std::log(3 / (1 - alpha)) / N) + 1)));

--- a/cpp/tests/gradient_operator.cc
+++ b/cpp/tests/gradient_operator.cc
@@ -26,7 +26,7 @@ TEST_CASE("Gradient Operator") {
   Image const image = sopt::notinstalled::read_standard_tiff("cameraman256");
   auto const psi = sopt::gradient_operator::gradient_operator<Scalar>(image.rows(), image.cols());
   Matrix input = Matrix::Ones(image.rows(), image.cols());
-  for (Eigen::Index i(0); i < image.rows(); i++) input.row(i) *= static_cast<Scalar>(i);
+  for (Eigen::Index i(0); i < image.rows(); ++i) input.row(i) *= static_cast<Scalar>(i);
   Vector output = psi.adjoint() * Vector::Map(input.data(), input.size());
   CAPTURE(output.segment(0, 5));
   CAPTURE(output.segment(image.size(), 5));
@@ -35,7 +35,7 @@ TEST_CASE("Gradient Operator") {
   CHECK(output.segment(input.size(), input.size() - 1)
             .isApprox(Vector::Constant(0.5, input.size() - 1)));
   input = Matrix::Ones(image.rows(), image.cols());
-  for (Eigen::Index i(0); i < image.cols(); i++) input.col(i) *= static_cast<Scalar>(i);
+  for (Eigen::Index i(0); i < image.cols(); ++i) input.col(i) *= static_cast<Scalar>(i);
   output = psi.adjoint() * Vector::Map(input.data(), input.size());
   CAPTURE(output.segment(0, 5));
   CAPTURE(output.segment(image.size(), 5));

--- a/cpp/tests/inpainting.cc
+++ b/cpp/tests/inpainting.cc
@@ -50,7 +50,7 @@ TEST_CASE("Inpainting"){
 
   std::normal_distribution<> gaussian_dist(0, sigma);
   Vector y(y0.size());
-  for (sopt::t_int i = 0; i < y0.size(); i++) y(i) = y0(i) + gaussian_dist(*mersenne);
+  for (sopt::t_int i = 0; i < y0.size(); ++i) y(i) = y0(i) + gaussian_dist(*mersenne);
 
   sopt::t_real const gamma = 18;
   sopt::t_real const beta = sigma * sigma * 0.5;

--- a/cpp/tests/serial_vs_parallel_padmm.cc
+++ b/cpp/tests/serial_vs_parallel_padmm.cc
@@ -69,7 +69,7 @@ TEST_CASE("Parallel vs serial inpainting") {
   std::normal_distribution<> gaussian_dist(0, sigma);
   Vector y = world.is_root() ? y0 : world.broadcast<Vector>();
   if (world.is_root()) {
-    for (sopt::t_int i = 0; i < y0.size(); i++) y(i) += gaussian_dist(*mersenne);
+    for (sopt::t_int i = 0; i < y0.size(); ++i) y(i) += gaussian_dist(*mersenne);
     world.broadcast(y);
   }
   if (split_comm.size() > 1) {

--- a/cpp/tests/tf_inpainting.cc
+++ b/cpp/tests/tf_inpainting.cc
@@ -46,7 +46,7 @@ TEST_CASE("Inpainting"){
 
   std::normal_distribution<> gaussian_dist(0, sigma);
   Vector y(y0.size());
-  for (sopt::t_int i = 0; i < y0.size(); i++) y(i) = y0(i) + gaussian_dist(*mersenne);
+  for (sopt::t_int i = 0; i < y0.size(); ++i) y(i) = y0(i) + gaussian_dist(*mersenne);
 
   sopt::t_real const gamma = 18;
   sopt::t_real const beta = sigma * sigma * 0.5;

--- a/cpp/tests/wavelets.cc
+++ b/cpp/tests/wavelets.cc
@@ -60,7 +60,7 @@ void check_round_trip(Eigen::ArrayBase<T0> const &input_, sopt::t_uint db,
 }
 
 TEST_CASE("wavelet data") {
-  for (sopt::t_int num = 1; num < 100; num++) {
+  for (sopt::t_int num = 1; num < 100; ++num) {
     if (num < 39)
       REQUIRE(sopt::wavelets::daubechies_data(num).coefficients.size() == 2 * num);
     else

--- a/cpp/tools_for_tests/inpainting.h
+++ b/cpp/tools_for_tests/inpainting.h
@@ -29,7 +29,7 @@ Vector<T> dirty(sopt::LinearTransform<Vector<T>> const &sampling, sopt::Image<T>
   auto const y0 = target(sampling, image);
   std::normal_distribution<> gaussian_dist(0, sigma(sampling, image));
   Vector<T> y(y0.size());
-  for (t_int i = 0; i < y0.size(); i++) y(i) = y0(i) + gaussian_dist(mersenne);
+  for (t_int i = 0; i < y0.size(); ++i) y(i) = y0(i) + gaussian_dist(mersenne);
 
   return y;
 }


### PR DESCRIPTION
There is no reason whatsoever to use the postfix versions of the increment and decrement operator.

In postfix incrementing, first, a copy of the operand is made. Then the operand (not the copy) is incremented. Finally, the copy (not the original) is evaluated. Then the temporary copy is discarded. The postfix version takes a lot more steps, and thus may not be as performant as the prefix version.

In practice, any non-toy compiler will optimise away these steps and the postfix version is likely to have the same performance as the prefix versions for fundamental data types and even for compound types. 

However, for user-defined data types where these operators may be overloaded, the postfix version is likely to be slower. 

### References
- https://stackoverflow.com/a/7031409
- https://stackoverflow.com/a/24904  (performance discussion)
- https://www.learncpp.com/cpp-tutorial/increment-decrement-operators-and-side-effects/

There should be no reason whatsoever to use these postfix operators, and we should strive to break this old habit asap.