### PR TITLE
Surrounds macros with parenthesis to force evaluation before usage

### DIFF
--- a/cpp/sopt/forward_backward.h
+++ b/cpp/sopt/forward_backward.h
@@ -75,7 +75,7 @@ class ForwardBackward {
 // auto sdmm  = ForwardBackward<float>().prop0(value).prop1(value);
 #define SOPT_MACRO(NAME, TYPE)                      \
   TYPE const &NAME() const { return NAME##_; }      \
-  ForwardBackward<SCALAR> &NAME(TYPE const &NAME) { \
+  ForwardBackward<SCALAR> &NAME(TYPE const &(NAME)) { \
     NAME##_ = NAME;                                 \
     return *this;                                   \
   }                                                 \

--- a/cpp/sopt/imaging_forward_backward.h
+++ b/cpp/sopt/imaging_forward_backward.h
@@ -79,7 +79,7 @@ class ImagingForwardBackward {
 // auto padmm = ImagingForwardBackward<float>().prop0(value).prop1(value);
 #define SOPT_MACRO(NAME, TYPE)                             \
   TYPE const &NAME() const { return NAME##_; }             \
-  ImagingForwardBackward<SCALAR> &NAME(TYPE const &NAME) { \
+  ImagingForwardBackward<SCALAR> &NAME(TYPE const &(NAME)) { \
     NAME##_ = NAME;                                        \
     return *this;                                          \
   }                                                        \

--- a/cpp/sopt/imaging_padmm.h
+++ b/cpp/sopt/imaging_padmm.h
@@ -72,7 +72,7 @@ class ImagingProximalADMM {
 // auto padmm = ImagingProximalADMM<float>().prop0(value).prop1(value);
 #define SOPT_MACRO(NAME, TYPE)                          \
   TYPE const &NAME() const { return NAME##_; }          \
-  ImagingProximalADMM<SCALAR> &NAME(TYPE const &NAME) { \
+  ImagingProximalADMM<SCALAR> &NAME(TYPE const &(NAME)) { \
     NAME##_ = NAME;                                     \
     return *this;                                       \
   }                                                     \
@@ -211,7 +211,7 @@ class ImagingProximalADMM {
   }                                                                                                \
   /** \brief Forwards to l1_proximal **/                                                           \
   ImagingProximalADMM<Scalar> &NAME##_proximal_##VAR(                                              \
-      decltype(std::declval<proximal::PROXIMAL<Scalar> const>().VAR()) VAR) {                      \
+      decltype(std::declval<proximal::PROXIMAL<Scalar> const>().VAR()) (VAR)) {                      \
     NAME##_proximal().VAR(VAR);                                                                    \
     return *this;                                                                                  \
   }

--- a/cpp/sopt/imaging_primal_dual.h
+++ b/cpp/sopt/imaging_primal_dual.h
@@ -84,7 +84,7 @@ class ImagingPrimalDual {
 // auto padmm = ImagingPrimalDual<float>().prop0(value).prop1(value);
 #define SOPT_MACRO(NAME, TYPE)                        \
   TYPE const &NAME() const { return NAME##_; }        \
-  ImagingPrimalDual<SCALAR> &NAME(TYPE const &NAME) { \
+  ImagingPrimalDual<SCALAR> &NAME(TYPE const &(NAME)) { \
     NAME##_ = NAME;                                   \
     return *this;                                     \
   }                                                   \
@@ -243,7 +243,7 @@ class ImagingPrimalDual {
   }                                                                                                \
   /** \brief Forwards to l1_proximal **/                                                           \
   ImagingPrimalDual<Scalar> &NAME##_proximal_##VAR(                                                \
-      decltype(std::declval<proximal::PROXIMAL<Scalar> const>().VAR()) VAR) {                      \
+      decltype(std::declval<proximal::PROXIMAL<Scalar> const>().VAR()) (VAR)) {                      \
     NAME##_proximal().VAR(VAR);                                                                    \
     return *this;                                                                                  \
   }

--- a/cpp/sopt/joint_map.h
+++ b/cpp/sopt/joint_map.h
@@ -46,7 +46,7 @@ class JointMAP {
 
 #define SOPT_MACRO(NAME, TYPE)                  \
   TYPE const &NAME() const { return NAME##_; }  \
-  JointMAP<ALGORITHM> &NAME(TYPE const &NAME) { \
+  JointMAP<ALGORITHM> &NAME(TYPE const &(NAME)) { \
     NAME##_ = NAME;                             \
     return *this;                               \
   }                                             \

--- a/cpp/sopt/l1_proximal.h
+++ b/cpp/sopt/l1_proximal.h
@@ -49,7 +49,7 @@ class L1TightFrame {
 
 #define SOPT_MACRO(NAME, TYPE)                   \
   TYPE const &NAME() const { return NAME##_; }   \
-  L1TightFrame<Scalar> &NAME(TYPE const &NAME) { \
+  L1TightFrame<Scalar> &NAME(TYPE const &(NAME)) { \
     NAME##_ = NAME;                              \
     return *this;                                \
   }                                              \
@@ -253,7 +253,7 @@ class L1 : protected L1TightFrame<SCALAR> {
 
 #define SOPT_MACRO(NAME, TYPE)                 \
   TYPE const &NAME() const { return NAME##_; } \
-  L1<Scalar> &NAME(TYPE const &NAME) {         \
+  L1<Scalar> &NAME(TYPE const &(NAME)) {         \
     NAME##_ = NAME;                            \
     return *this;                              \
   }                                            \

--- a/cpp/sopt/l2_forward_backward.h
+++ b/cpp/sopt/l2_forward_backward.h
@@ -82,7 +82,7 @@ class L2ForwardBackward {
 // auto padmm = L2ForwardBackward<float>().prop0(value).prop1(value);
 #define SOPT_MACRO(NAME, TYPE)                             \
   TYPE const &NAME() const { return NAME##_; }             \
-  L2ForwardBackward<SCALAR> &NAME(TYPE const &NAME) { \
+  L2ForwardBackward<SCALAR> &NAME(TYPE const &(NAME)) { \
     NAME##_ = NAME;                                        \
     return *this;                                          \
   }                                                        \

--- a/cpp/sopt/l2_primal_dual.h
+++ b/cpp/sopt/l2_primal_dual.h
@@ -83,7 +83,7 @@ class ImagingPrimalDual {
 // auto padmm = ImagingPrimalDual<float>().prop0(value).prop1(value);
 #define SOPT_MACRO(NAME, TYPE)                        \
   TYPE const &NAME() const { return NAME##_; }        \
-  ImagingPrimalDual<SCALAR> &NAME(TYPE const &NAME) { \
+  ImagingPrimalDual<SCALAR> &NAME(TYPE const &(NAME)) { \
     NAME##_ = NAME;                                   \
     return *this;                                     \
   }                                                   \
@@ -241,7 +241,7 @@ class ImagingPrimalDual {
   }                                                                                                \
   /** \brief Forwards to l2ball_proximal **/                                                       \
   ImagingPrimalDual<Scalar> &NAME##_proximal_##VAR(                                                \
-      decltype(std::declval<proximal::PROXIMAL<Scalar> const>().VAR()) VAR) {                      \
+      decltype(std::declval<proximal::PROXIMAL<Scalar> const>().VAR()) (VAR)) {                      \
     NAME##_proximal().VAR(VAR);                                                                    \
     return *this;                                                                                  \
   }

--- a/cpp/sopt/padmm.h
+++ b/cpp/sopt/padmm.h
@@ -72,7 +72,7 @@ class ProximalADMM {
 // auto sdmm  = ProximalADMM<float>().prop0(value).prop1(value);
 #define SOPT_MACRO(NAME, TYPE)                   \
   TYPE const &NAME() const { return NAME##_; }   \
-  ProximalADMM<SCALAR> &NAME(TYPE const &NAME) { \
+  ProximalADMM<SCALAR> &NAME(TYPE const &(NAME)) { \
     NAME##_ = NAME;                              \
     return *this;                                \
   }                                              \

--- a/cpp/sopt/power_method.h
+++ b/cpp/sopt/power_method.h
@@ -165,7 +165,7 @@ class PowerMethod {
 // auto sdmm  = ProximalADMM<float>().prop0(value).prop1(value);
 #define SOPT_MACRO(NAME, TYPE)                  \
   TYPE const &NAME() const { return NAME##_; }  \
-  PowerMethod<SCALAR> &NAME(TYPE const &NAME) { \
+  PowerMethod<SCALAR> &NAME(TYPE const &(NAME)) { \
     NAME##_ = NAME;                             \
     return *this;                               \
   }                                             \

--- a/cpp/sopt/primal_dual.h
+++ b/cpp/sopt/primal_dual.h
@@ -94,7 +94,7 @@ class PrimalDual {
 // auto sdmm  = PrimalDual<float>().prop0(value).prop1(value);
 #define SOPT_MACRO(NAME, TYPE)                 \
   TYPE const &NAME() const { return NAME##_; } \
-  PrimalDual<SCALAR> &NAME(TYPE const &NAME) { \
+  PrimalDual<SCALAR> &NAME(TYPE const &(NAME)) { \
     NAME##_ = NAME;                            \
     return *this;                              \
   }                                            \

--- a/cpp/sopt/sdmm.h
+++ b/cpp/sopt/sdmm.h
@@ -60,7 +60,7 @@ class SDMM {
 // auto sdmm  = SDMM<float>().prop0(value).prop1(value);
 #define SOPT_MACRO(NAME, TYPE)                 \
   TYPE const &NAME() const { return NAME##_; } \
-  SDMM<SCALAR> &NAME(TYPE const &NAME) {       \
+  SDMM<SCALAR> &NAME(TYPE const &(NAME)) {       \
     NAME##_ = NAME;                            \
     return *this;                              \
   }                                            \

--- a/cpp/sopt/tv_primal_dual.h
+++ b/cpp/sopt/tv_primal_dual.h
@@ -83,7 +83,7 @@ class TVPrimalDual {
 // auto padmm = TVPrimalDual<float>().prop0(value).prop1(value);
 #define SOPT_MACRO(NAME, TYPE)                   \
   TYPE const &NAME() const { return NAME##_; }   \
-  TVPrimalDual<SCALAR> &NAME(TYPE const &NAME) { \
+  TVPrimalDual<SCALAR> &NAME(TYPE const &(NAME)) { \
     NAME##_ = NAME;                              \
     return *this;                                \
   }                                              \
@@ -241,7 +241,7 @@ class TVPrimalDual {
   }                                                                                                \
   /** \brief Forwards to l1_proximal **/                                                           \
   TVPrimalDual<Scalar> &NAME##_proximal_##VAR(                                                     \
-      decltype(std::declval<proximal::PROXIMAL<Scalar> const>().VAR()) VAR) {                      \
+      decltype(std::declval<proximal::PROXIMAL<Scalar> const>().VAR()) (VAR)) {                      \
     NAME##_proximal().VAR(VAR);                                                                    \
     return *this;                                                                                  \
   }

--- a/cpp/sopt/wavelets/sara.h
+++ b/cpp/sopt/wavelets/sara.h
@@ -115,9 +115,9 @@ class SARA : public std::vector<Wavelet> {
 };
 
 #define SOPT_WAVELET_ERROR_MACRO(INPUT)                                           \
-  if (INPUT.rows() % (1u << max_levels()) != 0)                                   \
+  if ((INPUT).rows() % (1u << max_levels()) != 0)                                   \
     throw std::length_error("Inconsistent number of columns and wavelet levels"); \
-  else if (INPUT.cols() != 1 and INPUT.cols() % (1u << max_levels()))             \
+  else if ((INPUT).cols() != 1 and (INPUT).cols() % (1u << max_levels()))             \
     throw std::length_error("Inconsistent number of rows and wavelet levels");
 
 template <class T0, class T1>

--- a/cpp/sopt/wavelets/wavelets.h
+++ b/cpp/sopt/wavelets/wavelets.h
@@ -29,16 +29,16 @@ class Wavelet : public WaveletData {
 
 // Temporary macros that checks constraints on input
 #define SOPT_WAVELET_MACRO_MULTIPLE(NAME)                                                   \
-  if ((NAME.rows() == 1 or NAME.cols() == 1)) {                                             \
-    if (NAME.size() % (1 << levels()) != 0)                                                 \
+  if (((NAME).rows() == 1 or (NAME).cols() == 1)) {                                             \
+    if ((NAME).size() % (1 << levels()) != 0)                                                 \
       throw std::length_error("Size of " #NAME " must number a multiple of 2^levels or 1"); \
-  } else if (NAME.rows() != 1 and NAME.rows() % (1 << levels()) != 0)                       \
+  } else if ((NAME).rows() != 1 and (NAME).rows() % (1 << levels()) != 0)                       \
     throw std::length_error("Rows of " #NAME " must number a multiple of 2^levels or 1");   \
-  else if (NAME.cols() % (1 << levels()) != 0)                                              \
+  else if ((NAME).cols() % (1 << levels()) != 0)                                              \
     throw std::length_error("Columns of " #NAME " must number a multiple of 2^levels");
 #define SOPT_WAVELET_MACRO_EQUAL_SIZE(A, B)                                                 \
-  if (A.rows() != B.rows() or A.cols() != B.cols()) A.derived().resize(B.rows(), B.cols()); \
-  if (A.rows() != B.rows() or A.cols() != B.cols())                                         \
+  if ((A).rows() != (B).rows() or (A).cols() != (B).cols()) (A).derived().resize((B).rows(), (B).cols()); \
+  if ((A).rows() != (B).rows() or (A).cols() != (B).cols())                                         \
   throw std::length_error("Incorrect size for output matrix(or could not resize)")
   //! \brief Direct transform
   //! \param[in] signal: computes wavelet coefficients for this signal. Its size must be a


### PR DESCRIPTION
> Macros are expanded by the preprocessor as-is. As a result, there can be unexpected behavior; operators may be evaluated in unexpected order and unary operators may become binary operators, etc.
> 
> When the replacement list has an expression, it is recommended to surround it with parentheses. This ensures that the macro result is evaluated completely before it is used.
> 
> It is also recommended to surround macro arguments in the replacement list with parentheses. This ensures that the argument value is calculated properly.

Refer to [this answer](https://stackoverflow.com/a/10820389) (and other answers on the page) on StackOverflow for further explanation with examples.

Additional references: 
- https://stackoverflow.com/questions/7186504/c-macros-and-use-of-arguments-in-parentheses
- https://wiki.sei.cmu.edu/confluence/display/c/PRE01-C.+Use+parentheses+within+macros+around+parameter+names