### PR TITLE
Cleans up redundant namespace closing and reopening within same file

### DIFF
--- a/cpp/sopt/bisection_method.h
+++ b/cpp/sopt/bisection_method.h
@@ -13,8 +13,7 @@ template <class K>
 typename std::enable_if<std::is_same<t_real, K>::value, K>::type bisection_method(
     const K &function_value, const std::function<K(K)> &func, const K &a, const K &b,
     const t_real &rel_convergence = 1e-4);
-}  // namespace sopt
-namespace sopt {
+
 template <class K>
 typename std::enable_if<std::is_same<t_real, K>::value, K>::type bisection_method(
     const K &function_value, const std::function<K(K)> &func, const K &a, const K &b,

--- a/cpp/sopt/credible_region.h
+++ b/cpp/sopt/credible_region.h
@@ -53,9 +53,6 @@ credible_interval(const Eigen::MatrixBase<T> &solution, const t_uint &rows, cons
                   const std::tuple<t_uint, t_uint> &grid_pixel_size,
                   const std::function<t_real(typename T::PlainObject)> &objective_function,
                   const t_real &alpha);
-} // namespace sopt::credible_region
-
-namespace sopt::credible_region {
 
 template <class T>
 t_real compute_energy_upper_bound(

--- a/cpp/sopt/objective_functions.h
+++ b/cpp/sopt/objective_functions.h
@@ -30,8 +30,6 @@ std::function<t_real(T)> const unconstrained_l1_regularisation(
     const t_real &gamma, const t_real &sig, const T &y,
     const sopt::LinearTransform<T> &measurement_operator,
     const sopt::LinearTransform<T> &wavelet_operator);
-} // namespace sopt::objective_functions
-namespace sopt::objective_functions {
 
 template <class T>
 std::function<t_real(T)> const unconstrained_regularisation(


### PR DESCRIPTION
Discussed in code review of #370. Closes #390.

The offending files can be searched for using ripgrep's multiline-mode regex:
```
rg -Ul '^\} *\/\/ *\bnamespace\b(.*)$\n*(?:^ *$)*^ *\bnamespace\b *\1' cpp/
```