### PR TITLE
Replace problematic use of 0 with the C++11 keyword nullptr as argument to std::time

### DIFF
--- a/cpp/examples/forward_backward/inpainting.cc
+++ b/cpp/examples/forward_backward/inpainting.cc
@@ -46,9 +46,9 @@ int main(int argc, char const **argv) {
     exit(0);
   }
   // Set up random numbers for C and C++
-  auto const seed = std::time(0);
+  auto const seed = std::time(nullptr);
   std::srand(static_cast<unsigned int>(seed));
-  std::mt19937 mersenne(std::time(0));
+  std::mt19937 mersenne(std::time(nullptr));
 
   // Initializes and sets logger (if compiled with logging)
   // See set_level function for levels.

--- a/cpp/examples/forward_backward/inpainting_credible_interval.cc
+++ b/cpp/examples/forward_backward/inpainting_credible_interval.cc
@@ -47,9 +47,9 @@ int main(int argc, char const **argv) {
     exit(0);
   }
   // Set up random numbers for C and C++
-  auto const seed = std::time(0);
+  auto const seed = std::time(nullptr);
   std::srand(static_cast<unsigned int>(seed));
-  std::mt19937 mersenne(std::time(0));
+  std::mt19937 mersenne(std::time(nullptr));
 
   // Initializes and sets logger (if compiled with logging)
   // See set_level function for levels.

--- a/cpp/examples/forward_backward/inpainting_joint_map.cc
+++ b/cpp/examples/forward_backward/inpainting_joint_map.cc
@@ -47,9 +47,9 @@ int main(int argc, char const **argv) {
     exit(0);
   }
   // Set up random numbers for C and C++
-  auto const seed = std::time(0);
+  auto const seed = std::time(nullptr);
   std::srand(static_cast<unsigned int>(seed));
-  std::mt19937 mersenne(std::time(0));
+  std::mt19937 mersenne(std::time(nullptr));
 
   // Initializes and sets logger (if compiled with logging)
   // See set_level function for levels.

--- a/cpp/examples/forward_backward/l2_inpainting.cc
+++ b/cpp/examples/forward_backward/l2_inpainting.cc
@@ -44,9 +44,9 @@ int main(int argc, char const **argv) {
     exit(0);
   }
   // Set up random numbers for C and C++
-  auto const seed = std::time(0);
+  auto const seed = std::time(nullptr);
   std::srand(static_cast<unsigned int>(seed));
-  std::mt19937 mersenne(std::time(0));
+  std::mt19937 mersenne(std::time(nullptr));
 
   // Initializes and sets logger (if compiled with logging)
   // See set_level function for levels.

--- a/cpp/examples/primal_dual/inpainting.cc
+++ b/cpp/examples/primal_dual/inpainting.cc
@@ -54,9 +54,9 @@ int main(int argc, char const **argv) {
     exit(0);
   }
   // Set up random numbers for C and C++
-  auto const seed = std::time(0);
+  auto const seed = std::time(nullptr);
   std::srand(static_cast<unsigned int>(seed));
-  std::mt19937 mersenne(std::time(0));
+  std::mt19937 mersenne(std::time(nullptr));
 
   // Initializes and sets logger (if compiled with logging)
   // See set_level function for levels.

--- a/cpp/examples/primal_dual/tv_inpainting.cc
+++ b/cpp/examples/primal_dual/tv_inpainting.cc
@@ -52,9 +52,9 @@ int main(int argc, char const **argv) {
     exit(0);
   }
   // Set up random numbers for C and C++
-  auto const seed = std::time(0);
+  auto const seed = std::time(nullptr);
   std::srand(static_cast<unsigned int>(seed));
-  std::mt19937 mersenne(std::time(0));
+  std::mt19937 mersenne(std::time(nullptr));
 
   // Initializes and sets logger (if compiled with logging)
   // See set_level function for levels.

--- a/cpp/examples/proximal_admm/inpainting.cc
+++ b/cpp/examples/proximal_admm/inpainting.cc
@@ -45,9 +45,9 @@ int main(int argc, char const **argv) {
     exit(0);
   }
   // Set up random numbers for C and C++
-  auto const seed = std::time(0);
+  auto const seed = std::time(nullptr);
   std::srand(static_cast<unsigned int>(seed));
-  std::mt19937 mersenne(std::time(0));
+  std::mt19937 mersenne(std::time(nullptr));
 
   // Initializes and sets logger (if compiled with logging)
   // See set_level function for levels.

--- a/cpp/examples/proximal_admm/reweighted.cc
+++ b/cpp/examples/proximal_admm/reweighted.cc
@@ -48,9 +48,9 @@ int main(int argc, char const **argv) {
     exit(0);
   }
   // Set up random numbers for C and C++
-  auto const seed = std::time(0);
+  auto const seed = std::time(nullptr);
   std::srand(static_cast<unsigned int>(seed));
-  std::mt19937 mersenne(std::time(0));
+  std::mt19937 mersenne(std::time(nullptr));
 
   // Initializes and sets logger (if compiled with logging)
   // See set_level function for levels.

--- a/cpp/examples/sdmm/inpainting.cc
+++ b/cpp/examples/sdmm/inpainting.cc
@@ -45,9 +45,9 @@ int main(int argc, char const **argv) {
     exit(0);
   }
   // Set up random numbers for C and C++
-  auto const seed = std::time(0);
+  auto const seed = std::time(nullptr);
   std::srand(static_cast<unsigned int>(seed));
-  std::mt19937 mersenne(std::time(0));
+  std::mt19937 mersenne(std::time(nullptr));
 
   // Initializes and sets logger (if compiled with logging)
   // See set_level function for levels.

--- a/cpp/examples/sdmm/reweighted.cc
+++ b/cpp/examples/sdmm/reweighted.cc
@@ -49,9 +49,9 @@ int main(int argc, char const **argv) {
     exit(0);
   }
   // Set up random numbers for C and C++
-  auto const seed = std::time(0);
+  auto const seed = std::time(nullptr);
   std::srand(static_cast<unsigned int>(seed));
-  std::mt19937 mersenne(std::time(0));
+  std::mt19937 mersenne(std::time(nullptr));
 
   // Initializes and sets logger (if compiled with logging)
   // See set_level function for levels.


### PR DESCRIPTION
C++11 introduced the `nullptr` keyword to avoid the problematic ambiguities surrounding the use of NULL or 0 (inherited from C).

As per [the cppreference page](https://en.cppreference.com/w/cpp/chrono/c/time) on `std::time`, its argument must be a:
> pointer to a [std::time_t](https://en.cppreference.com/w/cpp/chrono/c/time_t) object to store the time, or a **null pointer**

Whilst 0 will work, it is quite ambiguous in usage.

### Further references:
- Paper written by Stroustrup & Sutter: https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2431.pdf
- https://stackoverflow.com/questions/13816385/what-are-the-advantages-of-using-nullptr