### PR TITLE
Code-quality: Replace multiple declarations in single line with one declaration per line

### DIFF
--- a/cpp/examples/forward_backward/inpainting_credible_interval.cc
+++ b/cpp/examples/forward_backward/inpainting_credible_interval.cc
@@ -141,7 +141,9 @@ int main(int argc, char const **argv) {
            0.5 * std::pow(sopt::l2_norm(sampling * x - y), 2) / (sigma * sigma);
   };
 
-  sopt::Image<sopt::t_real> lower_error, upper_error, mean_solution;
+  sopt::Image<sopt::t_real> lower_error;
+  sopt::Image<sopt::t_real> upper_error;
+  sopt::Image<sopt::t_real> mean_solution;
   std::tie(lower_error, mean_solution, upper_error) =
       sopt::credible_region::credible_interval<sopt::Vector<sopt::t_real>, sopt::t_real>(
           diagnostic.x, image.rows(), image.cols(), grid_pixel_size, objective_function, alpha);

--- a/cpp/examples/l1_norm.cc
+++ b/cpp/examples/l1_norm.cc
@@ -2,7 +2,8 @@
 #include "sopt/types.h"
 
 int main(int, char const **) {
-  sopt::Image<std::complex<int>> input(2, 2), weights(2, 2);
+  sopt::Image<std::complex<int>> input(2, 2);
+  sopt::Image<std::complex<int>> weights(2, 2);
   input << 1, -2, 3, -4;
   weights << 5, 6, 7, 8;
 

--- a/cpp/sopt/mpi/communicator.cc
+++ b/cpp/sopt/mpi/communicator.cc
@@ -13,7 +13,8 @@ void Communicator::delete_comm(Communicator::Impl *const impl) {
 
 Communicator::Communicator(MPI_Comm const &comm) : impl(nullptr), session(session_singleton()) {
   if (comm == MPI_COMM_NULL) return;
-  int size, rank;
+  int size;
+  int rank;
   MPI_Comm_size(comm, &size);
   MPI_Comm_rank(comm, &rank);
 

--- a/cpp/sopt/mpi/communicator.h
+++ b/cpp/sopt/mpi/communicator.h
@@ -294,7 +294,8 @@ typename std::enable_if<is_registered_type<T>::value, Vector<T>>::type Communica
     return vec;
   }
   if (rank() != root) return scatterv<T>(sizes.at(rank()), root);
-  std::vector<int> sizes_, displs;
+  std::vector<int> sizes_;
+  std::vector<int> displs;
   int i = 0;
   for (auto const size : sizes) {
     sizes_.push_back(static_cast<int>(size));
@@ -354,14 +355,16 @@ Communicator::all_to_allv(const std::vector<T> &vec, std::vector<t_int> const &s
   }
 
   int i = 0;
-  std::vector<int> ssizes_, sdispls;
+  std::vector<int> ssizes_;
+  std::vector<int> sdispls;
   for (auto const size : send_sizes) {
     ssizes_.push_back(static_cast<int>(size));
     sdispls.push_back(i);
     i += size;
   }
   int total = 0;
-  std::vector<int> rsizes_, rdispls;
+  std::vector<int> rsizes_;
+  std::vector<int> rdispls;
   for (auto const size : rec_sizes) {
     rsizes_.push_back(static_cast<int>(size));
     rdispls.push_back(total);
@@ -404,14 +407,16 @@ typename std::enable_if<is_registered_type<T>::value, Vector<T>>::type Communica
   }
 
   int i = 0;
-  std::vector<int> ssizes_, sdispls;
+  std::vector<int> ssizes_;
+  std::vector<int> sdispls;
   for (auto const size : send_sizes) {
     ssizes_.push_back(static_cast<int>(size));
     sdispls.push_back(i);
     i += size;
   }
   int total = 0;
-  std::vector<int> rsizes_, rdispls;
+  std::vector<int> rsizes_;
+  std::vector<int> rdispls;
   for (auto const size : rec_sizes) {
     rsizes_.push_back(static_cast<int>(size));
     rdispls.push_back(total);
@@ -456,7 +461,8 @@ CONTAINER Communicator::gather_(CONTAINER const &vec, std::vector<t_int> const &
 
   if (rank() != root) return gather_<CONTAINER, T>(vec, root);
 
-  std::vector<int> sizes_, displs;
+  std::vector<int> sizes_;
+  std::vector<int> displs;
   int result_size = 0;
   for (auto const size : sizes) {
     sizes_.push_back(static_cast<int>(size));

--- a/cpp/sopt/sdmm.h
+++ b/cpp/sopt/sdmm.h
@@ -206,7 +206,8 @@ typename SDMM<SCALAR>::Diagnostic SDMM<SCALAR>::operator()(t_Vector &out,
 
   SOPT_HIGH_LOG("Performing SDMM ");
   out = input;
-  t_Vectors y(transforms().size()), z(transforms().size());
+  t_Vectors y(transforms().size());
+  t_Vectors z(transforms().size());
 
   // Initial step replaces iteration update with initialization
   initialization(y, z, input);

--- a/cpp/sopt/utilities.cc
+++ b/cpp/sopt/utilities.cc
@@ -40,7 +40,9 @@ Image<> read_tiff(std::string const &filename) {
   TIFF *tif = TIFFOpen(filename.c_str(), "r");
   if (not tif) SOPT_THROW("Could not open file ") << filename;
 
-  uint32_t width, height, t;
+  uint32_t width;
+  uint32_t height;
+  uint32_t t;
 
   TIFFGetField(tif, TIFFTAG_IMAGEWIDTH, &width);
   TIFFGetField(tif, TIFFTAG_IMAGELENGTH, &height);

--- a/cpp/tests/chained_operators.cc
+++ b/cpp/tests/chained_operators.cc
@@ -22,7 +22,8 @@ TEST_CASE("Linear Transforms", "[ops]") {
     t_Vector const x = t_Vector::Random(2 * N) * 5;
     auto chain = chained_operators(func0);
 
-    t_Vector actual, expected;
+    t_Vector actual;
+    t_Vector expected;
     func0(actual, x);
     chain(expected, x);
     CHECK(actual == expected);
@@ -38,7 +39,8 @@ TEST_CASE("Linear Transforms", "[ops]") {
     t_Vector const x = t_Vector::Random(2 * N) * 5;
     auto chain = chained_operators(func0, func1);
 
-    t_Vector actual, expected;
+    t_Vector actual;
+    t_Vector expected;
     func1(expected, x);
     func0(actual, expected);
     chain(expected, x);
@@ -55,7 +57,8 @@ TEST_CASE("Linear Transforms", "[ops]") {
     t_Vector const x = t_Vector::Random(2 * N) * 5;
     auto chain = chained_operators(func0, func1, func0);
 
-    t_Vector actual, expected;
+    t_Vector actual;
+    t_Vector expected;
     func0(actual, x);
     func1(expected, actual);
     func0(actual, expected);
@@ -73,7 +76,8 @@ TEST_CASE("Linear Transforms", "[ops]") {
     t_Vector const x = t_Vector::Random(2 * N) * 5;
     auto chain = chained_operators(func0, func1, func0, func0);
 
-    t_Vector actual, expected;
+    t_Vector actual;
+    t_Vector expected;
     func0(expected, x);
     func0(actual, expected);
     func1(expected, actual);
@@ -101,7 +105,8 @@ TEST_CASE("Linear Transforms", "[ops]") {
     auto chain = chained_operators(func0, func1, func0, func0);
     auto chain_adjoint = chained_operators(afunc0, afunc0, afunc1, afunc0);
     auto op = LinearTransform<t_Vector>{chain, chain_adjoint};
-    t_Vector actual, expected;
+    t_Vector actual;
+    t_Vector expected;
     chain(actual, x);
     expected = op * x;
     CHECK(expected == x.head(N - 1) * 32);

--- a/cpp/tests/communicator.cc
+++ b/cpp/tests/communicator.cc
@@ -9,7 +9,8 @@ using namespace sopt;
 
 #ifdef SOPT_MPI
 TEST_CASE("Creates an mpi communicator") {
-  int rank, size;
+  int rank;
+  int size;
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   MPI_Comm_size(MPI_COMM_WORLD, &size);
 
@@ -42,7 +43,8 @@ TEST_CASE("Creates an mpi communicator") {
   }
 
   SECTION("ScatterV") {
-    std::vector<t_int> sizes(world.size()), displs(world.size());
+    std::vector<t_int> sizes(world.size());
+    std::vector<t_int> displs(world.size());
     for (t_uint i(0); i < world.rank(); ++i) sizes[i] = world.rank() * 2 + i;
     for (t_uint i(1); i < world.rank(); ++i) displs[i] = displs[i - 1] + sizes[i - 1];
     Vector<t_int> const sendee =

--- a/cpp/tests/sara.cc
+++ b/cpp/tests/sara.cc
@@ -59,7 +59,8 @@ TEST_CASE("Linear-transform wrapper", "[wavelet]") {
   SARA const sara{std::make_tuple(std::string{"DB3"}, 1u), std::make_tuple(std::string{"DB1"}, 2u),
                   std::make_tuple(std::string{"DB1"}, 3u)};
   SECTION("1d") {
-    auto const rows = 256, cols = 1;
+    auto const rows = 256;
+    auto const cols = 1;
     auto const Psi = linear_transform<t_real>(sara, rows, cols);
     SECTION("Indirect transform") {
       Image<> const image = Image<>::Random(rows, cols);
@@ -90,7 +91,8 @@ TEST_CASE("Linear-transform wrapper", "[wavelet]") {
     }
   }
   SECTION("2d") {
-    auto const rows = 256, cols = 256;
+    auto const rows = 256;
+    auto const cols = 256;
     auto const Psi = linear_transform<t_real>(sara, rows, cols);
     SECTION("Indirect transform") {
       Image<> const image = Image<>::Random(rows, cols);

--- a/cpp/tests/wavelets.cc
+++ b/cpp/tests/wavelets.cc
@@ -175,7 +175,8 @@ TEST_CASE("Wavelet transform innards with integer data", "[wavelet]") {
       auto const low = random_ivector(Nfilters, -10, 10);
       auto const high = random_ivector(Nfilters, -10, 10);
 
-      t_iVector actual(Ncoeffs), expected(Ncoeffs);
+      t_iVector actual(Ncoeffs);
+      t_iVector expected(Ncoeffs);
       // does all in go, more complicated but compuationally less intensive
       up_convolve_sum(actual, coeffs, even(low), odd(low), even(high), odd(high));
       // first up-samples, then does convolve: conceptually simpler but does unnecessary operations
@@ -197,7 +198,8 @@ TEST_CASE("1D wavelet transform with floating point data", "[wavelet]") {
 
   SECTION("Direct transform == two downsample + convolution") {
     auto const actual = direct_transform(data.row(0), 1, wavelet);
-    Array<> high(data.cols() / 2), low(data.cols() / 2);
+    Array<> high(data.cols() / 2);
+    Array<> low(data.cols() / 2);
     down_convolve(high, data.row(0), wavelet.direct_filter.high);
     down_convolve(low, data.row(0), wavelet.direct_filter.low);
     CHECK(low.transpose().isApprox(actual.head(data.row(0).size() / 2)));


### PR DESCRIPTION
The codebase has several files wherein several identifiers are declared in the same line (#397). This is poor practice. This PR shall close #397.

The [C++ core guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines.html), a living document co-authored by Stroustrup and Sutter, states in [ES.10](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Res-name-one) that 

> #### ES.10: Declare one name (only) per declaration
> ##### Reason
> 
> One declaration per line increases readability and avoids mistakes related to the C/C++ grammar. It also leaves room for a more descriptive end-of-line comment. 
> ##### Example
> ```cpp
> char *p, c, a[7], *pp[7], **aa[10];   // yuck!
> ```
> ##### Example
> ```cpp
> int a = 10, b = 11, c = 12, d, e = 14, f = 15;
> ```
> In a long list of declarators it is easy to overlook an uninitialized variable. In the above example, integer variable `d` is not initialized.

