### PR TITLE
Modernize: replace a couple of more c-style casts with c++ style casts

### DIFF
--- a/cpp/sopt/utilities.cc
+++ b/cpp/sopt/utilities.cc
@@ -20,7 +20,7 @@ double convert_to_greyscale(uint32_t &pixel) {
 //! Converts greyscale double value to RGBA
 uint32_t convert_from_greyscale(double pixel) {
   uint32_t result = 0;
-  uint8_t *ptr = (uint8_t *)&result;
+  uint8_t *ptr = reinterpret_cast<uint8_t *>(&result);
   auto const g = [](double p) -> uint8_t {
     auto const scaled = 255e0 * p;
     if (scaled < 0) return 0;
@@ -53,7 +53,7 @@ Image<> read_tiff(std::string const &filename) {
   if (not TIFFReadRGBAImage(tif, width, height, raster, 0))
     SOPT_THROW("Could not read file ") << filename;
 
-  uint32_t *pixel = (uint32_t *)raster;
+  uint32_t *pixel = raster;
   for (uint32_t i(0); i < height; ++i)
     for (uint32_t j(0); j < width; ++j, ++pixel) result(i, j) = convert_to_greyscale(*pixel);
 


### PR DESCRIPTION
Found a couple of more opportunities to clean up C-style casts. The majority were already fixed in #374. Should fully address #375.

___________________________________________________________

According to [this](https://stackoverflow.com/a/1609185) answer on stackoverflow,

>  - C++ style casts are checked by the compiler. C style casts aren't and can fail at runtime.
>  - Also, C++ style casts can be searched for easily, whereas it's really hard to search for C style casts.
>  - Another big benefit is that the 4 different C++ style casts express the intent of the programmer more clearly.
>  - When writing C++ I'd pretty much always use the C++ ones over the the C style.

________________

According to [this](https://stackoverflow.com/a/18414126) answer on stackoverflow,

> -  static_cast<>() gives you a compile time checking ability, C-Style cast doesn't.
> -  static_cast<>() is more readable and can be spotted easily anywhere inside a C++ source code, C_Style cast is'nt.
> -  Intentions are conveyed much better using C++ casts.

______________________________

#### Further reading at [learncpp](https://www.learncpp.com/cpp-tutorial/explicit-type-conversion-casting-and-static-cast/)

> Although a C-style cast appears to be a single cast, it can actually perform a variety of different conversions depending on context. This can include a static cast, a const cast or a reinterpret cast (the latter two of which we mentioned above you should avoid). As a result, C-style casts are at risk for being inadvertently misused and not producing the expected behavior, something which is easily avoidable by using the C++ casts instead.
> Also, because C-style casts are just a type name, parenthesis, and variable or value, they are both difficult to identify (making your code harder to read) and even more difficult to search for.

> The main advantage of static_cast is that it provides compile-time type checking, making it harder to make an inadvertent error.
> static_cast is also (intentionally) less powerful than C-style casts, so you can’t inadvertently remove const or do other things you may not have intended to do.