### PR TITLE
Code-quality: replaces a deprecated header (assert.h with cassert)

### DIFF
--- a/cpp/tests/primal_dual.cc
+++ b/cpp/tests/primal_dual.cc
@@ -1,7 +1,7 @@
 #include <catch.hpp>
 #include <random>
 
-#include <assert.h>
+#include <cassert>
 
 #include <Eigen/Dense>
 


### PR DESCRIPTION
See the discussion [here](https://stackoverflow.com/questions/13889467/should-i-include-xxxx-h-or-cxxxx-in-c-programs) on StackOverflow for a general overview,

And [this](https://stackoverflow.com/questions/43011737/is-it-better-to-include-cassert-or-assert-h) thread on StackOverflow in particular on `assert.h` vs `cassert`.