### PR TITLE
Performance: In a test file, we preallocate vector instead of dynamically expanding within a loop

### DIFF
--- a/cpp/tests/linear_transform.cc
+++ b/cpp/tests/linear_transform.cc
@@ -68,6 +68,7 @@ TEST_CASE("Array of Linear transforms", "[ops]") {
   t_Vector const x = t_Vector::Random(N) * 5;
   std::vector<t_Matrix> Ls{t_Matrix::Random(N, N), t_Matrix::Random(N, N)};
   std::vector<LinearTransform<t_Vector>> ops;
+  ops.reserve(Ls.size());
   for (auto const &matrix : Ls) ops.emplace_back(sopt::linear_transform(matrix));
 
   for (decltype(Ls)::size_type i(0); i < ops.size(); ++i) {


### PR DESCRIPTION
If its capacity is full, `std::vector` will resize on demand (usually by a factor of 2) when emplace_back is called. However,  this involves reallocation of memory with the desired capacity, copying the current contents into the newly allocated memory, and then deallocating the current memory. If done within a loop (as it is currently done in one of the tests now), this could potentially be quite expensive.

For performance reasons, if we know the required size, it is better to preallocate memory for `std::vector`, and simply populate it within the loop.