### PR TITLE
Add explicit qualification to auto-typed variable that is deduced to pointer

### DIFF
--- a/cpp/tests/communicator.cc
+++ b/cpp/tests/communicator.cc
@@ -149,7 +149,7 @@ TEST_CASE("Creates an mpi communicator") {
     }
 
     SECTION("std::string") {
-      auto const expected = "Hello World!";
+      const auto *const expected = "Hello World!";
       std::string const input = world.is_root() ? expected : "";
       CHECK(world.broadcast(input) == expected);
     }


### PR DESCRIPTION
[LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#beware-unnecessary-copies-with-auto) (quoted below) advises to make it obvious if a auto typed variable is a pointer.

> The convenience of `auto` makes it easy to forget that its default behavior is a copy. Particularly in range-based for loops, careless copies are expensive.
> 
> Use `auto &` for values and `auto *` for pointers unless you need to make a copy.