### PR TITLE
Modernize: use auto wherever possible for object initialisation

### DIFF
--- a/cpp/sopt/utilities.cc
+++ b/cpp/sopt/utilities.cc
@@ -20,7 +20,7 @@ double convert_to_greyscale(uint32_t &pixel) {
 //! Converts greyscale double value to RGBA
 uint32_t convert_from_greyscale(double pixel) {
   uint32_t result = 0;
-  uint8_t *ptr = (uint8_t *)&result;
+  auto *ptr = (uint8_t *)&result;
   auto const g = [](double p) -> uint8_t {
     auto const scaled = 255e0 * p;
     if (scaled < 0) return 0;
@@ -48,12 +48,12 @@ Image<> read_tiff(std::string const &filename) {
   SOPT_LOW_LOG("- image size {}, {} ", width, height);
   Image<> result = Image<>::Zero(height, width);
 
-  uint32_t *raster = static_cast<uint32_t *>(_TIFFmalloc(width * height * sizeof(uint32_t)));
+  auto *raster = static_cast<uint32_t *>(_TIFFmalloc(width * height * sizeof(uint32_t)));
   if (not raster) SOPT_THROW("Could not allocate memory to read file ") << filename;
   if (not TIFFReadRGBAImage(tif, width, height, raster, 0))
     SOPT_THROW("Could not read file ") << filename;
 
-  uint32_t *pixel = (uint32_t *)raster;
+  auto *pixel = (uint32_t *)raster;
   for (uint32_t i(0); i < height; ++i)
     for (uint32_t j(0); j < width; ++j, ++pixel) result(i, j) = convert_to_greyscale(*pixel);
 

--- a/cpp/sopt/wavelets/direct.h
+++ b/cpp/sopt/wavelets/direct.h
@@ -19,7 +19,7 @@ template <class T0, class T1>
 typename std::enable_if<T1::IsVectorAtCompileTime, void>::type direct_transform_impl(
     Eigen::ArrayBase<T0> const &coeffs_, Eigen::ArrayBase<T1> const &signal,
     WaveletData const &wavelet) {
-  Eigen::ArrayBase<T0> &coeffs = const_cast<Eigen::ArrayBase<T0> &>(coeffs_);
+  auto &coeffs = const_cast<Eigen::ArrayBase<T0> &>(coeffs_);
   assert(coeffs.size() == signal.size());
   assert(wavelet.direct_filter.low.size() == wavelet.direct_filter.high.size());
 
@@ -36,8 +36,8 @@ template <class T0, class T1>
 typename std::enable_if<not T1::IsVectorAtCompileTime, void>::type direct_transform_impl(
     Eigen::ArrayBase<T0> const &coeffs_, Eigen::ArrayBase<T1> const &signal_,
     WaveletData const &wavelet) {
-  Eigen::ArrayBase<T0> &coeffs = const_cast<Eigen::ArrayBase<T0> &>(coeffs_);
-  Eigen::ArrayBase<T1> &signal = const_cast<Eigen::ArrayBase<T1> &>(signal_);
+  auto &coeffs = const_cast<Eigen::ArrayBase<T0> &>(coeffs_);
+  auto &signal = const_cast<Eigen::ArrayBase<T1> &>(signal_);
   assert(coeffs.rows() == signal.rows());
   assert(coeffs.cols() == signal.cols());
   assert(wavelet.direct_filter.low.size() == wavelet.direct_filter.high.size());
@@ -83,7 +83,7 @@ typename std::enable_if<not T1::IsVectorAtCompileTime, void>::type direct_transf
     WaveletData const &wavelet) {
   assert(coeffs_.rows() == signal.rows());
   assert(coeffs_.cols() == signal.cols());
-  Eigen::ArrayBase<T0> &coeffs = const_cast<Eigen::ArrayBase<T0> &>(coeffs_);
+  auto &coeffs = const_cast<Eigen::ArrayBase<T0> &>(coeffs_);
 
   if (levels == 0) {
     coeffs = signal;

--- a/cpp/sopt/wavelets/indirect.h
+++ b/cpp/sopt/wavelets/indirect.h
@@ -19,7 +19,7 @@ template <class T0, class T1>
 typename std::enable_if<T1::IsVectorAtCompileTime, void>::type indirect_transform_impl(
     Eigen::ArrayBase<T0> const &coeffs, Eigen::ArrayBase<T1> const &signal_,
     WaveletData const &wavelet) {
-  Eigen::ArrayBase<T1> &signal = const_cast<Eigen::ArrayBase<T1> &>(signal_);
+  auto &signal = const_cast<Eigen::ArrayBase<T1> &>(signal_);
 
   assert(coeffs.size() == signal.size());
   assert(coeffs.size() % 2 == 0);
@@ -35,8 +35,8 @@ template <class T0, class T1>
 typename std::enable_if<not T1::IsVectorAtCompileTime, void>::type indirect_transform_impl(
     Eigen::ArrayBase<T0> const &coeffs_, Eigen::ArrayBase<T1> const &signal_,
     WaveletData const &wavelet) {
-  Eigen::ArrayBase<T0> &coeffs = const_cast<Eigen::ArrayBase<T0> &>(coeffs_);
-  Eigen::ArrayBase<T1> &signal = const_cast<Eigen::ArrayBase<T1> &>(signal_);
+  auto &coeffs = const_cast<Eigen::ArrayBase<T0> &>(coeffs_);
+  auto &signal = const_cast<Eigen::ArrayBase<T1> &>(signal_);
   assert(coeffs.rows() == signal.rows() and coeffs.cols() == signal.cols());
   assert(coeffs.rows() % 2 == 0 and coeffs.cols() % 2 == 0);
 
@@ -82,8 +82,8 @@ template <class T0, class T1>
 typename std::enable_if<not T1::IsVectorAtCompileTime, void>::type indirect_transform(
     Eigen::ArrayBase<T0> const &coeffs_, Eigen::ArrayBase<T1> const &signal_, t_uint levels,
     WaveletData const &wavelet) {
-  Eigen::ArrayBase<T0> &coeffs = const_cast<Eigen::ArrayBase<T0> &>(coeffs_);
-  Eigen::ArrayBase<T1> &signal = const_cast<Eigen::ArrayBase<T1> &>(signal_);
+  auto &coeffs = const_cast<Eigen::ArrayBase<T0> &>(coeffs_);
+  auto &signal = const_cast<Eigen::ArrayBase<T1> &>(signal_);
   assert(coeffs.rows() == signal.rows());
   assert(coeffs.cols() == signal.cols());
   assert(coeffs.size() % (1u << levels) == 0);


### PR DESCRIPTION
The [C++ core guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines.html), a living document co-authored by Stroustrup and Sutter, states in [ES.11](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Res-auto) that:

> ### ES.11: Use auto to avoid redundant repetition of type names
> #### Reason
> 
>  - Simple repetition is tedious and error-prone.
>  - When you use `auto`, the name of the declared entity is in a fixed position in the declaration, increasing readability.
>  - In a function template declaration the return type can be a member type.
> 
> ##### Example
> 
> Consider:
> ```cpp
> auto p = v.begin();      // vector<DataRecord>::iterator
> auto z1 = v[3];          // makes copy of DataRecord
> auto& z2 = v[3];         // avoids copy
> const auto& z3 = v[3];   // const and avoids copy
> auto h = t.future();
> auto q = make_unique<int[]>(s);
> auto f = [](int x) { return x + 10; };
> ```
> In each case, we save writing a longish, hard-to-remember type that the compiler already knows but a programmer could get wrong.