### PR TITLE
Modernise: For type template parameters, replaces the old keyword 'class' with 'typename'

### DIFF
--- a/cpp/benchmarks/conjugate_gradient.cc
+++ b/cpp/benchmarks/conjugate_gradient.cc
@@ -2,7 +2,7 @@
 #include <sstream>
 #include <benchmark/benchmark.h>
 
-template <class TYPE>
+template <typename TYPE>
 void matrix_cg(benchmark::State &state) {
   auto const N = state.range_x();
   auto const epsilon = std::pow(10, -state.range_y());
@@ -17,7 +17,7 @@ void matrix_cg(benchmark::State &state) {
   state.SetBytesProcessed(int64_t(state.iterations()) * int64_t(N) * sizeof(TYPE));
 }
 
-template <class TYPE>
+template <typename TYPE>
 void function_cg(benchmark::State &state) {
   auto const N = state.range_x();
   auto const epsilon = std::pow(10, -state.range_y());

--- a/cpp/benchmarks/l1_proximal.cc
+++ b/cpp/benchmarks/l1_proximal.cc
@@ -4,7 +4,7 @@
 #include "sopt/real_type.h"
 #include "sopt/types.h"
 
-template <class TYPE>
+template <typename TYPE>
 void function_l1p(benchmark::State &state) {
   using Real = typename sopt::real_type<TYPE>::type;
   auto const N = state.range_x();

--- a/cpp/benchmarks/wavelets.cc
+++ b/cpp/benchmarks/wavelets.cc
@@ -12,7 +12,7 @@ std::string get_name(unsigned db) {
   return sstr.str();
 }
 
-template <class TYPE, unsigned DB = 1, unsigned LEVEL = 1>
+template <typename TYPE, unsigned DB = 1, unsigned LEVEL = 1>
 void direct_matrix(benchmark::State &state) {
   auto const Nx = get_size(state.range_x(), LEVEL);
   auto const Ny = get_size(state.range_y(), LEVEL);
@@ -23,7 +23,7 @@ void direct_matrix(benchmark::State &state) {
   state.SetBytesProcessed(int64_t(state.iterations()) * int64_t(Nx) * int64_t(Ny) * sizeof(TYPE));
 }
 
-template <class TYPE, unsigned DB = 1, unsigned LEVEL = 1>
+template <typename TYPE, unsigned DB = 1, unsigned LEVEL = 1>
 void indirect_matrix(benchmark::State &state) {
   auto const Nx = get_size(state.range_x(), LEVEL);
   auto const Ny = get_size(state.range_y(), LEVEL);
@@ -34,7 +34,7 @@ void indirect_matrix(benchmark::State &state) {
   state.SetBytesProcessed(int64_t(state.iterations()) * int64_t(Nx) * int64_t(Ny) * sizeof(TYPE));
 }
 
-template <class TYPE, unsigned DB = 1, unsigned LEVEL = 1>
+template <typename TYPE, unsigned DB = 1, unsigned LEVEL = 1>
 void direct_vector(benchmark::State &state) {
   auto const Nx = get_size(state.range_x(), LEVEL);
   auto const input = sopt::Array<TYPE>::Random(Nx).eval();
@@ -43,7 +43,7 @@ void direct_vector(benchmark::State &state) {
   while (state.KeepRunning()) wavelet.direct(output, input);
   state.SetBytesProcessed(int64_t(state.iterations()) * int64_t(Nx) * sizeof(TYPE));
 }
-template <class TYPE, unsigned DB = 1, unsigned LEVEL = 1>
+template <typename TYPE, unsigned DB = 1, unsigned LEVEL = 1>
 void indirect_vector(benchmark::State &state) {
   auto const Nx = get_size(state.range_x(), LEVEL);
   auto const input = sopt::Array<TYPE>::Random(Nx).eval();

--- a/cpp/sopt/bisection_method.h
+++ b/cpp/sopt/bisection_method.h
@@ -9,13 +9,13 @@
 
 namespace sopt {
 //! Find root to a function within an interval
-template <class K>
+template <typename K>
 typename std::enable_if<std::is_same<t_real, K>::value, K>::type bisection_method(
     const K &function_value, const std::function<K(K)> &func, const K &a, const K &b,
     const t_real &rel_convergence = 1e-4);
 }  // namespace sopt
 namespace sopt {
-template <class K>
+template <typename K>
 typename std::enable_if<std::is_same<t_real, K>::value, K>::type bisection_method(
     const K &function_value, const std::function<K(K)> &func, const K &a, const K &b,
     const t_real &rel_convergence) {

--- a/cpp/sopt/chained_operators.h
+++ b/cpp/sopt/chained_operators.h
@@ -8,7 +8,7 @@
 #include "sopt/types.h"
 
 namespace sopt {
-template <class T0, class... T>
+template <typename T0, typename... T>
 OperatorFunction<T0> chained_operators(OperatorFunction<T0> const &arg0, T const &... args) {
   if (sizeof...(args) == 0) return arg0;
 

--- a/cpp/sopt/conjugate_gradient.h
+++ b/cpp/sopt/conjugate_gradient.h
@@ -14,7 +14,7 @@ namespace sopt {
 class ConjugateGradient {
   //! \brief Wraps around a matrix to fake a functor
   //! \details xout = A * xin becomes apply_matrix_instance(xout, xin);
-  template <class T>
+  template <typename T>
   class ApplyMatrix;
 
  public:
@@ -28,7 +28,7 @@ class ConjugateGradient {
     bool good;
   };
   //! Values indicating how the algorithm ran and its result;
-  template <class T>
+  template <typename T>
   struct DiagnosticAndResult : public Diagnostic {
     Vector<T> result;
   };
@@ -45,7 +45,7 @@ class ConjugateGradient {
   //! This convertion is only so we write the conjugate-gradient algorithm only once for
   //! A as a matrix and A as a functor. A as a functor means A can be a complex operation, e.g. an
   //! FFT or two.
-  template <class VECTOR, class T1, class T2>
+  template <typename VECTOR, typename T1, typename T2>
   Diagnostic operator()(VECTOR &x, Eigen::MatrixBase<T1> const &A,
                         Eigen::MatrixBase<T2> const &b) const {
     return implementation(x, A, b);
@@ -53,7 +53,7 @@ class ConjugateGradient {
   //! \brief Computes $x$ for $Ax=b$
   //! \details Specialisation where A is a functor and b and x are matrix-like objects. This is
   //! the innermost specialization.
-  template <class VECTOR, class T1, class T2>
+  template <typename VECTOR, typename T1, typename T2>
   typename std::enable_if<not std::is_base_of<Eigen::EigenBase<T1>, T1>::value, Diagnostic>::type
   operator()(VECTOR &x, T1 const &A, Eigen::MatrixBase<T2> const &b) const {
     return implementation(x, details::wrap<typename VECTOR::PlainObject>(A), b);
@@ -61,7 +61,7 @@ class ConjugateGradient {
   //! \brief Computes $x$ for $Ax=b$
   //! \details Specialisation where x is constructed during call and returned. And x is a matrix
   //! rather than an array.
-  template <class T0, class A_TYPE>
+  template <typename T0, typename A_TYPE>
   DiagnosticAndResult<typename T0::Scalar> operator()(A_TYPE const &A,
                                                       Eigen::MatrixBase<T0> const &b) const {
     DiagnosticAndResult<typename T0::Scalar> result;
@@ -100,11 +100,11 @@ class ConjugateGradient {
   //! \brief Just one implementation for all types
   //! \note This is a template function, to avoid repetition, but it is not declared in the
   //! header.
-  template <class VECTOR, class T1, class MATRIXLIKE>
+  template <typename VECTOR, typename T1, typename MATRIXLIKE>
   Diagnostic implementation(VECTOR &x, MATRIXLIKE const &A, Eigen::MatrixBase<T1> const &b) const;
 };
 
-template <class VECTOR, class T1, class MATRIXLIKE>
+template <typename VECTOR, typename T1, typename MATRIXLIKE>
 ConjugateGradient::Diagnostic ConjugateGradient::implementation(
     VECTOR &x, MATRIXLIKE const &A, Eigen::MatrixBase<T1> const &b) const {
   using Scalar = typename T1::Scalar;

--- a/cpp/sopt/credible_region.h
+++ b/cpp/sopt/credible_region.h
@@ -15,19 +15,19 @@
 
 namespace sopt::credible_region {
 
-template <class T>
+template <typename T>
 t_real compute_energy_upper_bound(
     const t_real &alpha, const Eigen::MatrixBase<T> &solution,
     const std::function<t_real(typename T::PlainObject)> &objective_function);
 
-template <class T>
+template <typename T>
 std::tuple<t_real, t_real, t_real> find_credible_interval(
     const Eigen::MatrixBase<T> &solution, const t_uint &rows, const t_uint &cols,
     const std::tuple<t_uint, t_uint, t_uint, t_uint> &region,
     const std::function<t_real(typename T::PlainObject)> &objective_function,
     const t_real &energy_upperbound);
 
-template <class T, class K>
+template <typename T, typename K>
 typename std::enable_if<is_complex<K>::value or std::is_arithmetic<K>::value,
                         std::tuple<Image<K>, Image<K>, Image<K>>>::type
 credible_interval_grid(const Eigen::MatrixBase<T> &solution, const t_uint &rows, const t_uint &cols,
@@ -35,21 +35,21 @@ credible_interval_grid(const Eigen::MatrixBase<T> &solution, const t_uint &rows,
                        const std::function<t_real(typename T::PlainObject)> &objective_function,
                        const t_real &energy_upperbound);
 
-template <class T, class K>
+template <typename T, typename K>
 typename std::enable_if<is_complex<K>::value or std::is_arithmetic<K>::value,
                         std::tuple<Image<K>, Image<K>, Image<K>>>::type
 credible_interval_grid(const Eigen::MatrixBase<T> &solution, const t_uint &rows, const t_uint &cols,
                        const std::tuple<t_uint, t_uint> &grid_pixel_size,
                        const std::function<t_real(typename T::PlainObject)> &objective_function,
                        const t_real &energy_upperbound);
-template <class T, class K>
+template <typename T, typename K>
 typename std::enable_if<is_complex<K>::value or std::is_arithmetic<K>::value,
                         std::tuple<Image<K>, Image<K>, Image<K>>>::type
 credible_interval(const Eigen::MatrixBase<T> &solution, const t_uint &rows, const t_uint &cols,
                   const t_uint &grid_pixel_size,
                   const std::function<t_real(typename T::PlainObject)> &objective_function,
                   const t_real &alpha);
-template <class T, class K>
+template <typename T, typename K>
 typename std::enable_if<is_complex<K>::value or std::is_arithmetic<K>::value,
                         std::tuple<Image<K>, Image<K>, Image<K>>>::type
 credible_interval(const Eigen::MatrixBase<T> &solution, const t_uint &rows, const t_uint &cols,
@@ -60,7 +60,7 @@ credible_interval(const Eigen::MatrixBase<T> &solution, const t_uint &rows, cons
 
 namespace sopt::credible_region {
 
-template <class T>
+template <typename T>
 t_real compute_energy_upper_bound(
     const t_real &alpha, const Eigen::MatrixBase<T> &solution,
     const std::function<t_real(typename T::PlainObject)> &objective_function) {
@@ -74,7 +74,7 @@ t_real compute_energy_upper_bound(
   return gamma;
 }
 
-template <class T>
+template <typename T>
 std::tuple<t_real, t_real, t_real> find_credible_interval(
     const Eigen::MatrixBase<T> &solution, const t_uint &rows, const t_uint &cols,
     const std::tuple<t_uint, t_uint, t_uint, t_uint> &region,
@@ -114,7 +114,7 @@ std::tuple<t_real, t_real, t_real> find_credible_interval(
       sopt::bisection_method(energy_upperbound, bound_estimater, 0., b, 1e-3);
   return std::make_tuple(bound_lower, mean, bound_upper);
 }
-template <class T, class K>
+template <typename T, typename K>
 typename std::enable_if<is_complex<K>::value or std::is_arithmetic<K>::value,
                         std::tuple<Image<K>, Image<K>, Image<K>>>::type
 credible_interval_grid(const Eigen::MatrixBase<T> &solution, const t_uint &rows, const t_uint &cols,
@@ -127,7 +127,7 @@ credible_interval_grid(const Eigen::MatrixBase<T> &solution, const t_uint &rows,
       solution, rows, cols, grid_pixel_size_2d, objective_function, energy_upperbound);
 }
 
-template <class T, class K>
+template <typename T, typename K>
 typename std::enable_if<is_complex<K>::value or std::is_arithmetic<K>::value,
                         std::tuple<Image<K>, Image<K>, Image<K>>>::type
 credible_interval_grid(const Eigen::MatrixBase<T> &solution, const t_uint &rows, const t_uint &cols,
@@ -175,7 +175,7 @@ credible_interval_grid(const Eigen::MatrixBase<T> &solution, const t_uint &rows,
   }
   return std::make_tuple(credible_grid_lower_bound, credible_grid_mean, credible_grid_upper_bound);
 }
-template <class T, class K>
+template <typename T, typename K>
 typename std::enable_if<is_complex<K>::value or std::is_arithmetic<K>::value,
                         std::tuple<Image<K>, Image<K>, Image<K>>>::type
 credible_interval(const Eigen::MatrixBase<T> &solution, const t_uint &rows, const t_uint &cols,
@@ -186,7 +186,7 @@ credible_interval(const Eigen::MatrixBase<T> &solution, const t_uint &rows, cons
   return credible_interval_grid<typename T::PlainObject, K>(solution, rows, cols, grid_pixel_size,
                                                             objective_function, energy_upperbound);
 }
-template <class T, class K>
+template <typename T, typename K>
 typename std::enable_if<is_complex<K>::value or std::is_arithmetic<K>::value,
                         std::tuple<Image<K>, Image<K>, Image<K>>>::type
 credible_interval(const Eigen::MatrixBase<T> &solution, const t_uint &rows, const t_uint &cols,

--- a/cpp/sopt/exception.h
+++ b/cpp/sopt/exception.h
@@ -30,7 +30,7 @@ class Exception : public std::exception {
   }
 
   //! Adds to message
-  template <class OBJECT>
+  template <typename OBJECT>
   Exception &operator<<(OBJECT const &object) {
     std::ostringstream msg;
     msg << message << object;

--- a/cpp/sopt/forward_backward.h
+++ b/cpp/sopt/forward_backward.h
@@ -15,7 +15,7 @@ namespace sopt::algorithm {
 
 //! \brief Forward Backward Splitting
 //! \details \f$\min_{x} f(\Phi x - y) + g(z)\f$. \f$y\f$ is a target vector.
-template <class SCALAR>
+template <typename SCALAR>
 class ForwardBackward {
  public:
   //! Scalar type
@@ -58,7 +58,7 @@ class ForwardBackward {
   //! Setups ForwardBackward
   //! \param[in] f_gradient: gradient of the \f$f\f$ function.
   //! \param[in] g_proximal: proximal operator of the \f$g\f$ function
-  template <class DERIVED>
+  template <typename DERIVED>
   ForwardBackward(t_Gradient const &f_gradient, t_Proximal const &g_proximal,
                   Eigen::MatrixBase<DERIVED> const &target)
       : itermax_(std::numeric_limits<t_uint>::max()),
@@ -122,7 +122,7 @@ class ForwardBackward {
   //! Vector of target measurements
   t_Vector const &target() const { return target_; }
   //! Sets the vector of target measurements
-  template <class DERIVED>
+  template <typename DERIVED>
   ForwardBackward<Scalar> &target(Eigen::MatrixBase<DERIVED> const &target) {
     target_ = target;
     return *this;
@@ -176,7 +176,7 @@ class ForwardBackward {
     return result;
   }
   //! Set Φ and Φ^† using arguments that sopt::linear_transform understands
-  template <class... ARGS>
+  template <typename... ARGS>
   typename std::enable_if<sizeof...(ARGS) >= 1, ForwardBackward &>::type Phi(ARGS &&... args) {
     Phi_ = linear_transform(std::forward<ARGS>(args)...);
     return *this;
@@ -230,7 +230,7 @@ class ForwardBackward {
   t_Vector target_;
 };
 
-template <class SCALAR>
+template <typename SCALAR>
 void ForwardBackward<SCALAR>::iteration_step(t_Vector &out, t_Vector &residual, t_Vector &p,
                                              t_Vector &z, const t_real lambda) const {
   p = out;
@@ -242,7 +242,7 @@ void ForwardBackward<SCALAR>::iteration_step(t_Vector &out, t_Vector &residual, 
   residual = (Phi() * p) - target();
 }
 
-template <class SCALAR>
+template <typename SCALAR>
 typename ForwardBackward<SCALAR>::Diagnostic ForwardBackward<SCALAR>::operator()(
     t_Vector &out, t_Vector const &x_guess, t_Vector const &res_guess) const {
   SOPT_HIGH_LOG("Performing Forward Backward Splitting");

--- a/cpp/sopt/g_proximal.h
+++ b/cpp/sopt/g_proximal.h
@@ -7,14 +7,14 @@
 #include "sopt/forward_backward.h"
 
 // Abstract base class providing the interface to the g_proximal function
-template <class SCALAR> class GProximal {
+template <typename SCALAR> class GProximal {
 
   using FB = sopt::algorithm::ForwardBackward<SCALAR>;
   using Real = typename FB::Real;
   using t_Vector = typename FB::t_Vector;
   using t_Proximal = typename FB::t_Proximal;
   using t_LinearTransform = typename FB::t_LinearTransform;
-  
+
 public:
 
   // A function that prints a log message

--- a/cpp/sopt/gradient_operator.h
+++ b/cpp/sopt/gradient_operator.h
@@ -7,7 +7,7 @@
 
 namespace sopt::gradient_operator {
 //! Numerical derivative of 1d vector
-template <class T>
+template <typename T>
 Vector<T> diff(const Vector<T> &x) {
   if (x.size() < 2) return Vector<T>::Zero(x.size());
   Vector<T> output = Vector<T>::Zero(x.size());
@@ -15,7 +15,7 @@ Vector<T> diff(const Vector<T> &x) {
   return output;
 }
 //! Numerical derivative adjoint of 1d vector
-template <class T>
+template <typename T>
 Vector<T> diff_adjoint(const Vector<T> &x) {
   Vector<T> output = Vector<T>::Zero(x.size());
   output.segment(0, x.size() - 1) -= x.segment(0, x.size() - 1);
@@ -23,7 +23,7 @@ Vector<T> diff_adjoint(const Vector<T> &x) {
   return output;
 }
 //! Numerical derivative of 2d image
-template <class T>
+template <typename T>
 Vector<T> diff2d(const Vector<T> &x, const t_int rows, const t_int cols) {
   Matrix<T> output = Matrix<T>::Zero(rows, 2 * cols);
   const Matrix<T> &input_image = Matrix<T>::Map(x.data(), rows, cols);
@@ -34,7 +34,7 @@ Vector<T> diff2d(const Vector<T> &x, const t_int rows, const t_int cols) {
   return Vector<T>::Map(output.data(), output.size());
 }
 //! Numerical derivative adjoint of 2d image
-template <class T>
+template <typename T>
 Vector<T> diff2d_adjoint(const Vector<T> &x, const t_int rows, const t_int cols) {
   const Matrix<T> &input_image = Matrix<T>::Map(x.data(), rows, 2 * cols);
   Matrix<T> output = Matrix<T>::Zero(rows, cols);
@@ -44,7 +44,7 @@ Vector<T> diff2d_adjoint(const Vector<T> &x, const t_int rows, const t_int cols)
     output.col(i) += diff_adjoint<T>(input_image.block(0, cols, rows, cols).col(i));
   return Vector<T>::Map(output.data(), output.size());
 }
-template <class T>
+template <typename T>
 LinearTransform<Vector<T>> gradient_operator(const t_int rows, const t_int cols) {
   return LinearTransform<Vector<T>>(
       [rows, cols](Vector<T> &out, Vector<T> const &x) {

--- a/cpp/sopt/imaging_forward_backward.h
+++ b/cpp/sopt/imaging_forward_backward.h
@@ -22,7 +22,7 @@
 #endif
 
 namespace sopt::algorithm {
-template <class SCALAR>
+template <typename SCALAR>
 class ImagingForwardBackward {
   //! Underlying algorithm
   using FB = ForwardBackward<SCALAR>;
@@ -56,7 +56,7 @@ class ImagingForwardBackward {
   // Note: Using setter injection instead of constructior injection to follow the
   // style in the rest of the class, although constructor might be more appropriate
   //! \param[in] target: Vector of target measurements
-  template <class DERIVED>
+  template <typename DERIVED>
   ImagingForwardBackward(Eigen::MatrixBase<DERIVED> const &target)
     : g_proximal_(nullptr),
       l2_gradient_([](t_Vector &output, const t_Vector &x) -> void {
@@ -145,7 +145,7 @@ class ImagingForwardBackward {
   //! Minimun of objective_function
   Real objmin() const { return objmin_; }
   //! Sets the vector of target measurements
-  template <class DERIVED>
+  template <typename DERIVED>
   ImagingForwardBackward<Scalar> &target(Eigen::MatrixBase<DERIVED> const &target) {
     target_ = target;
     return *this;
@@ -198,7 +198,7 @@ class ImagingForwardBackward {
   }
 
   //! Set Φ and Φ^† using arguments that sopt::linear_transform understands
-  template <class... ARGS>
+  template <typename... ARGS>
   typename std::enable_if<sizeof...(ARGS) >= 1, ImagingForwardBackward &>::type Phi(
       ARGS &&... args) {
     Phi_ = linear_transform(std::forward<ARGS>(args)...);
@@ -256,7 +256,7 @@ class ImagingForwardBackward {
                     t_Vector const &residual) const;
 };
 
-template <class SCALAR>
+template <typename SCALAR>
 typename ImagingForwardBackward<SCALAR>::Diagnostic ImagingForwardBackward<SCALAR>::operator()(
     t_Vector &out, t_Vector const &guess, t_Vector const &res) const {
   g_proximal_->log_message();
@@ -287,7 +287,7 @@ typename ImagingForwardBackward<SCALAR>::Diagnostic ImagingForwardBackward<SCALA
   return result;
 }
 
-template <class SCALAR>
+template <typename SCALAR>
 bool ImagingForwardBackward<SCALAR>::residual_convergence(t_Vector const &x,
                                                           t_Vector const &residual) const {
   if (static_cast<bool>(residual_convergence())) return residual_convergence()(x, residual);
@@ -297,7 +297,7 @@ bool ImagingForwardBackward<SCALAR>::residual_convergence(t_Vector const &x,
   return residual_norm < residual_tolerance();
 }
 
-template <class SCALAR>
+template <typename SCALAR>
 bool ImagingForwardBackward<SCALAR>::objective_convergence(ScalarRelativeVariation<Scalar> &scalvar,
                                                            t_Vector const &x,
                                                            t_Vector const &residual) const {
@@ -309,7 +309,7 @@ bool ImagingForwardBackward<SCALAR>::objective_convergence(ScalarRelativeVariati
 }
 
 #ifdef SOPT_MPI
-template <class SCALAR>
+template <typename SCALAR>
 bool ImagingForwardBackward<SCALAR>::objective_convergence(mpi::Communicator const &obj_comm,
                                                            ScalarRelativeVariation<Scalar> &scalvar,
                                                            t_Vector const &x,
@@ -323,7 +323,7 @@ bool ImagingForwardBackward<SCALAR>::objective_convergence(mpi::Communicator con
 }
 #endif
 
-template <class SCALAR>
+template <typename SCALAR>
 bool ImagingForwardBackward<SCALAR>::is_converged(ScalarRelativeVariation<Scalar> &scalvar,
                                                   t_Vector const &x,
                                                   t_Vector const &residual) const {

--- a/cpp/sopt/imaging_padmm.h
+++ b/cpp/sopt/imaging_padmm.h
@@ -16,7 +16,7 @@
 #include "sopt/types.h"
 
 namespace sopt::algorithm {
-template <class SCALAR>
+template <typename SCALAR>
 class ImagingProximalADMM {
   //! Underlying algorithm
   using PADMM = ProximalADMM<SCALAR>;
@@ -51,7 +51,7 @@ class ImagingProximalADMM {
   //! Setups imaging wrapper for ProximalADMM
   //! \param[in] f_proximal: proximal operator of the \f$f\f$ function.
   //! \param[in] g_proximal: proximal operator of the \f$g\f$ function
-  template <class DERIVED>
+  template <typename DERIVED>
   ImagingProximalADMM(Eigen::MatrixBase<DERIVED> const &target)
       : l1_proximal_(),
         l2ball_proximal_(1e0),
@@ -123,7 +123,7 @@ class ImagingProximalADMM {
   //! Vector of target measurements
   t_Vector const &target() const { return target_; }
   //! Sets the vector of target measurements
-  template <class DERIVED>
+  template <typename DERIVED>
   ImagingProximalADMM<Scalar> &target(Eigen::MatrixBase<DERIVED> const &target) {
     target_ = target;
     return *this;
@@ -176,7 +176,7 @@ class ImagingProximalADMM {
   }
 
   //! Set Φ and Φ^† using arguments that sopt::linear_transform understands
-  template <class... ARGS>
+  template <typename... ARGS>
   typename std::enable_if<sizeof...(ARGS) >= 1, ImagingProximalADMM &>::type Phi(ARGS &&... args) {
     Phi_ = linear_transform(std::forward<ARGS>(args)...);
     return *this;
@@ -193,7 +193,7 @@ class ImagingProximalADMM {
   //! \details Under-the-hood, the object is actually owned by the L1 proximal.
   t_LinearTransform const &Psi() const { return l1_proximal().Psi(); }
   //! Analysis operator Ψ
-  template <class... ARGS>
+  template <typename... ARGS>
   typename std::enable_if<sizeof...(ARGS) >= 1, ImagingProximalADMM<Scalar> &>::type Psi(
       ARGS &&... args) {
     l1_proximal().Psi(std::forward<ARGS>(args)...);
@@ -256,7 +256,7 @@ class ImagingProximalADMM {
   Diagnostic operator()(t_Vector &out, t_Vector const &guess, t_Vector const &res) const;
 
   //! Calls l1 proximal operator, checking for real constraints and tight frame
-  template <class T0, class T1>
+  template <typename T0, typename T1>
   typename proximal::L1<Scalar>::Diagnostic l1_proximal(Eigen::MatrixBase<T0> &out, Real gamma,
                                                         Eigen::MatrixBase<T1> const &x) const {
     return l1_proximal_real_constraint()
@@ -265,7 +265,7 @@ class ImagingProximalADMM {
   }
 
   //! Calls l1 proximal operator, checking for thight frame
-  template <class T0, class T1>
+  template <typename T0, typename T1>
   typename proximal::L1<Scalar>::Diagnostic call_l1_proximal(Eigen::MatrixBase<T0> &out, Real gamma,
                                                              Eigen::MatrixBase<T1> const &x) const {
     if (tight_frame()) {
@@ -287,7 +287,7 @@ class ImagingProximalADMM {
                     t_Vector const &residual) const;
 };
 
-template <class SCALAR>
+template <typename SCALAR>
 typename ImagingProximalADMM<SCALAR>::Diagnostic ImagingProximalADMM<SCALAR>::operator()(
     t_Vector &out, t_Vector const &guess, t_Vector const &res) const {
   SOPT_HIGH_LOG("Performing Proximal ADMM with L1 and L2 operators");
@@ -315,7 +315,7 @@ typename ImagingProximalADMM<SCALAR>::Diagnostic ImagingProximalADMM<SCALAR>::op
   return result;
 }
 
-template <class SCALAR>
+template <typename SCALAR>
 bool ImagingProximalADMM<SCALAR>::residual_convergence(t_Vector const &x,
                                                        t_Vector const &residual) const {
   if (static_cast<bool>(residual_convergence())) return residual_convergence()(x, residual);
@@ -325,7 +325,7 @@ bool ImagingProximalADMM<SCALAR>::residual_convergence(t_Vector const &x,
   return residual_norm < residual_tolerance();
 }
 
-template <class SCALAR>
+template <typename SCALAR>
 bool ImagingProximalADMM<SCALAR>::objective_convergence(ScalarRelativeVariation<Scalar> &scalvar,
                                                         t_Vector const &x,
                                                         t_Vector const &residual) const {
@@ -336,7 +336,7 @@ bool ImagingProximalADMM<SCALAR>::objective_convergence(ScalarRelativeVariation<
   return scalvar(current);
 }
 
-template <class SCALAR>
+template <typename SCALAR>
 bool ImagingProximalADMM<SCALAR>::is_converged(ScalarRelativeVariation<Scalar> &scalvar,
                                                t_Vector const &x, t_Vector const &residual) const {
   auto const user = static_cast<bool>(is_converged()) == false or is_converged()(x, residual);

--- a/cpp/sopt/imaging_primal_dual.h
+++ b/cpp/sopt/imaging_primal_dual.h
@@ -16,7 +16,7 @@
 #include "sopt/types.h"
 
 namespace sopt::algorithm {
-template <class SCALAR>
+template <typename SCALAR>
 class ImagingPrimalDual {
   //! Underlying algorithm
   using PD = PrimalDual<SCALAR>;
@@ -27,7 +27,7 @@ class ImagingPrimalDual {
   using Real = typename PD::Real;
   using t_Vector = typename PD::t_Vector;
   using t_LinearTransform = typename PD::t_LinearTransform;
-  template <class T>
+  template <typename T>
   using t_Proximal = std::function<void(t_Vector &, const T &, const t_Vector &)>;
   using t_IsConverged = typename PD::t_IsConverged;
   using t_Constraint = typename PD::t_Constraint;
@@ -48,7 +48,7 @@ class ImagingPrimalDual {
   //! Setups imaging wrapper for PD
   //! \param[in] f_proximal: proximal operator of the \f$f\f$ function.
   //! \param[in] g_proximal: proximal operator of the \f$g\f$ function
-  template <class DERIVED>
+  template <typename DERIVED>
   ImagingPrimalDual(Eigen::MatrixBase<DERIVED> const &target)
       : l1_proximal_([](t_Vector &out, const Real &gamma, const t_Vector &x) {
           proximal::l1_norm<t_Vector, t_Vector>(out, gamma, x);
@@ -162,7 +162,7 @@ class ImagingPrimalDual {
   //! Vector of target measurements
   t_Vector const &target() const { return target_; }
   //! Sets the vector of target measurements
-  template <class DERIVED>
+  template <typename DERIVED>
   ImagingPrimalDual<Scalar> &target(Eigen::MatrixBase<DERIVED> const &target) {
     target_ = target;
     return *this;
@@ -215,7 +215,7 @@ class ImagingPrimalDual {
   }
 
   //! Set Φ and Φ^† using arguments that sopt::linear_transform understands
-  template <class... ARGS>
+  template <typename... ARGS>
   typename std::enable_if<sizeof...(ARGS) >= 1, ImagingPrimalDual &>::type Phi(ARGS &&... args) {
     Phi_ = linear_transform(std::forward<ARGS>(args)...);
     return *this;
@@ -226,7 +226,7 @@ class ImagingPrimalDual {
   proximal::WeightedL2Ball<Scalar> &l2ball_proximal() { return l2ball_proximal_; }
 
   //! Analysis operator Ψ
-  template <class... ARGS>
+  template <typename... ARGS>
   typename std::enable_if<sizeof...(ARGS) >= 1, ImagingPrimalDual &>::type Psi(ARGS &&... args) {
     Psi_ = linear_transform(std::forward<ARGS>(args)...);
     return *this;
@@ -300,7 +300,7 @@ class ImagingPrimalDual {
   }
 };
 
-template <class SCALAR>
+template <typename SCALAR>
 typename ImagingPrimalDual<SCALAR>::Diagnostic ImagingPrimalDual<SCALAR>::operator()(
     t_Vector &out, t_Vector const &guess, t_Vector const &res) const {
   SOPT_HIGH_LOG("Performing Primal Dual with L1 and L2 operators");
@@ -363,7 +363,7 @@ typename ImagingPrimalDual<SCALAR>::Diagnostic ImagingPrimalDual<SCALAR>::operat
   return result;
 }
 
-template <class SCALAR>
+template <typename SCALAR>
 bool ImagingPrimalDual<SCALAR>::residual_convergence(t_Vector const &x,
                                                      t_Vector const &residual) const {
   if (static_cast<bool>(residual_convergence())) return residual_convergence()(x, residual);
@@ -373,7 +373,7 @@ bool ImagingPrimalDual<SCALAR>::residual_convergence(t_Vector const &x,
   return residual_norm < residual_tolerance();
 }
 
-template <class SCALAR>
+template <typename SCALAR>
 bool ImagingPrimalDual<SCALAR>::objective_convergence(ScalarRelativeVariation<Scalar> &scalvar,
                                                       t_Vector const &x,
                                                       t_Vector const &residual) const {
@@ -384,7 +384,7 @@ bool ImagingPrimalDual<SCALAR>::objective_convergence(ScalarRelativeVariation<Sc
   return scalvar(current);
 }
 
-template <class SCALAR>
+template <typename SCALAR>
 bool ImagingPrimalDual<SCALAR>::is_converged(ScalarRelativeVariation<Scalar> &scalvar,
                                              t_Vector const &x, t_Vector const &residual) const {
   auto const user = static_cast<bool>(is_converged()) == false or is_converged()(x, residual);

--- a/cpp/sopt/joint_map.h
+++ b/cpp/sopt/joint_map.h
@@ -15,7 +15,7 @@
 
 namespace sopt::algorithm {
 
-template <class ALGORITHM>
+template <typename ALGORITHM>
 class JointMAP {
   using t_Vector = typename ALGORITHM::t_Vector;
   using t_Reg_Term = typename std::function<t_real (const t_Vector &)>;
@@ -91,7 +91,7 @@ class JointMAP {
  public:
   //! \brief Calls Joint MAP estimation
   //! \param[out] out: Diagnostic and Solution
-  template <class... ARGS>
+  template <typename... ARGS>
   DiagnosticAndResultReg operator()(ARGS &&... args) const {
     SOPT_HIGH_LOG("Performing Joint MAP estimation");
 

--- a/cpp/sopt/l1_g_proximal.h
+++ b/cpp/sopt/l1_g_proximal.h
@@ -24,7 +24,7 @@ namespace sopt::algorithm {
 // Implementation of g_proximal with l1 proximal.
 // Owns the private object l1_proximal_ and implements the
 // interface defined by the GProximal class
-template <class SCALAR>
+template <typename SCALAR>
 class L1GProximal : public GProximal<SCALAR> {
 
 public:
@@ -110,7 +110,7 @@ public:
 #undef SOPT_MACRO
 
   //! Analysis operator Ψ
-  template <class... ARGS>
+  template <typename... ARGS>
   typename std::enable_if<sizeof...(ARGS) >= 1, L1GProximal<SCALAR> &>::type Psi(
       ARGS &&... args) {
     l1_proximal().Psi(std::forward<ARGS>(args)...);
@@ -124,7 +124,7 @@ protected:
 
   // Helper functions for calling l1_proximal
   //! Calls l1 proximal operator, checking for real constraints
-  template <class T0, class T1>
+  template <typename T0, typename T1>
   typename proximal::L1<Scalar>::Diagnostic l1_proximal(Eigen::MatrixBase<T0> &out, Real gamma,
                                                         Eigen::MatrixBase<T1> const &x) const {
     return l1_proximal_real_constraint()
@@ -133,7 +133,7 @@ protected:
   }
 
   //! Calls l1 proximal operator, checking for tight frame
-  template <class T0, class T1>
+  template <typename T0, typename T1>
   typename proximal::L1<Scalar>::Diagnostic call_l1_proximal(Eigen::MatrixBase<T0> &out, Real gamma,
                                                              Eigen::MatrixBase<T1> const &x) const {
     if (tight_frame_) {

--- a/cpp/sopt/l1_proximal.h
+++ b/cpp/sopt/l1_proximal.h
@@ -22,7 +22,7 @@ namespace sopt::proximal {
 //!  \f[ min_{z} 0.5||x - z||_2^2 + γ ||Ψ^† z||_w1 \f]
 //!  where \f$Ψ \in C^{N_x \times N_r} \f$ is the sparsifying operator, and \f[|| ||_w1\f] is the
 //!  weighted L1 norm.
-template <class SCALAR>
+template <typename SCALAR>
 class L1TightFrame {
  public:
   //! Underlying scalar type
@@ -73,7 +73,7 @@ class L1TightFrame {
   //! Weights of the l1 norm
   Vector<Real> const &weights() const { return weights_; }
   //! Weights of the l1 norm
-  template <class T>
+  template <typename T>
   L1TightFrame<Scalar> &weights(Eigen::MatrixBase<T> const &w) {
     if ((w.array() < 0e0).any()) SOPT_THROW("Weights cannot be negative");
     if (w.stableNorm() < 1e-12) SOPT_THROW("Weights cannot be null");
@@ -89,27 +89,27 @@ class L1TightFrame {
   }
 
   //! Set Ψ and Ψ^† using arguments that sopt::linear_transform understands
-  template <class... ARGS>
+  template <typename... ARGS>
   typename std::enable_if<sizeof...(ARGS) >= 1, L1TightFrame &>::type Psi(ARGS &&... args) {
     Psi_ = linear_transform(std::forward<ARGS>(args)...);
     return *this;
   }
 
   //! Computes proximal for given γ
-  template <class T0, class T1>
+  template <typename T0, typename T1>
   typename std::enable_if<is_complex<Scalar>::value == is_complex<typename T0::Scalar>::value and
                           is_complex<Scalar>::value == is_complex<typename T1::Scalar>::value>::type
   operator()(Eigen::MatrixBase<T0> &out, Real gamma, Eigen::MatrixBase<T1> const &x) const;
 
   //! Lazy version
-  template <class T0>
+  template <typename T0>
   ProximalExpression<L1TightFrame<Scalar> const &, T0> operator()(
       Real const &gamma, Eigen::MatrixBase<T0> const &x) const {
     return {*this, gamma, x};
   }
 
   //! \f[ 0.5||x - z||_2^2 + γ||Ψ^† z||_w1 \f]
-  template <class T0, class T1>
+  template <typename T0, typename T1>
   typename std::enable_if<is_complex<Scalar>::value == is_complex<typename T0::Scalar>::value and
                               is_complex<Scalar>::value == is_complex<typename T1::Scalar>::value,
                           Real>::type
@@ -121,8 +121,8 @@ class L1TightFrame {
   Vector<Real> weights_;
 };
 
-template <class SCALAR>
-template <class T0, class T1>
+template <typename SCALAR>
+template <typename T0, typename T1>
 typename std::enable_if<is_complex<SCALAR>::value == is_complex<typename T0::Scalar>::value and
                         is_complex<SCALAR>::value == is_complex<typename T1::Scalar>::value>::type
 L1TightFrame<SCALAR>::operator()(Eigen::MatrixBase<T0> &out, Real gamma,
@@ -141,8 +141,8 @@ L1TightFrame<SCALAR>::operator()(Eigen::MatrixBase<T0> &out, Real gamma,
   SOPT_LOW_LOG("Prox L1: objective = {}", objective(x, out, gamma));
 }
 
-template <class SCALAR>
-template <class T0, class T1>
+template <typename SCALAR>
+template <typename T0, typename T1>
 typename std::enable_if<is_complex<SCALAR>::value == is_complex<typename T0::Scalar>::value and
                             is_complex<SCALAR>::value == is_complex<typename T1::Scalar>::value,
                         typename real_type<SCALAR>::type>::type
@@ -165,7 +165,7 @@ L1TightFrame<SCALAR>::objective(Eigen::MatrixBase<T0> const &x, Eigen::MatrixBas
 //!  \f[ min_{z} 0.5||x - z||_2^2 + γ ||Ψ^† z||_w1 \f]
 //!  where \f$Ψ \in C^{N_x \times N_r} \f$ is the sparsifying operator, and \f[|| ||_w1\f] is the
 //!  weighted L1 norm.
-template <class SCALAR>
+template <typename SCALAR>
 class L1 : protected L1TightFrame<SCALAR> {
  public:
   //! Functor to do fista mixing
@@ -211,7 +211,7 @@ class L1 : protected L1TightFrame<SCALAR> {
   };
 
   //! Computes proximal for given γ
-  template <class T0>
+  template <typename T0>
   Diagnostic operator()(Eigen::MatrixBase<T0> &out, Real gamma, Vector<Scalar> const &x) const {
     // Note that we *must* call eval on x, in case it is an expression involving out
     if (gamma <= 0) {
@@ -226,7 +226,7 @@ class L1 : protected L1TightFrame<SCALAR> {
   }
 
   //! Lazy version
-  template <class T0>
+  template <typename T0>
   DiagnosticAndResult operator()(Real const &gamma, Eigen::MatrixBase<T0> const &x) const {
     DiagnosticAndResult result;
     static_cast<Diagnostic &>(result) = operator()(result.proximal, gamma, x);
@@ -279,7 +279,7 @@ class L1 : protected L1TightFrame<SCALAR> {
   //! Weights of the l1 norm
   Vector<Real> const &weights() const { return L1TightFrame<Scalar>::weights(); }
   //! Set weights to an array of values
-  template <class T>
+  template <typename T>
   L1<Scalar> &weights(Eigen::MatrixBase<T> const &w) {
     L1TightFrame<Scalar>::weights(w);
     return *this;
@@ -301,7 +301,7 @@ class L1 : protected L1TightFrame<SCALAR> {
   //! Linear transform applied to input prior to L1 norm
   LinearTransform<Vector<Scalar>> const &Psi() const { return L1TightFrame<Scalar>::Psi(); }
   //! Set Ψ and Ψ^† using a matrix
-  template <class... ARGS>
+  template <typename... ARGS>
   typename std::enable_if<sizeof...(ARGS) >= 1, L1<Scalar> &>::type Psi(ARGS &&... args) {
     L1TightFrame<Scalar>::Psi(std::forward<ARGS>(args)...);
     return *this;
@@ -309,7 +309,7 @@ class L1 : protected L1TightFrame<SCALAR> {
 
   //! \brief Special case if Ψ ia a tight frame.
   //! \see L1TightFrame
-  template <class... T>
+  template <typename... T>
   auto tight_frame(T &&... args) const
       -> decltype(this->L1TightFrame<Scalar>::operator()(std::forward<T>(args)...)) {
     return this->L1TightFrame<Scalar>::operator()(std::forward<T>(args)...);
@@ -317,21 +317,21 @@ class L1 : protected L1TightFrame<SCALAR> {
 
  protected:
   //! Applies one or another soft-threshhold, depending on weight
-  template <class T1>
+  template <typename T1>
   Vector<SCALAR> apply_soft_threshhold(Real gamma, Eigen::MatrixBase<T1> const &x) const;
   //! Applies constraints to input expression
-  template <class T0, class T1>
+  template <typename T0, typename T1>
   void apply_constraints(Eigen::MatrixBase<T0> &out, Eigen::MatrixBase<T1> const &x) const;
 
   //! Operation with explicit mixing step
-  template <class T0, class MIXING>
+  template <typename T0, typename MIXING>
   Diagnostic operator()(Eigen::MatrixBase<T0> &out, Real gamma, Vector<Scalar> const &x,
                         MIXING mixing) const;
 };
 
 //! Computes proximal for given γ
-template <class SCALAR>
-template <class T0, class MIXING>
+template <typename SCALAR>
+template <typename T0, typename MIXING>
 typename L1<SCALAR>::Diagnostic L1<SCALAR>::operator()(Eigen::MatrixBase<T0> &out, Real gamma,
                                                        Vector<Scalar> const &x,
                                                        MIXING mixing) const {
@@ -367,8 +367,8 @@ typename L1<SCALAR>::Diagnostic L1<SCALAR>::operator()(Eigen::MatrixBase<T0> &ou
   return {niters, breaker.relative_variation(), breaker.current(), breaker.converged()};
 }
 
-template <class SCALAR>
-template <class T1>
+template <typename SCALAR>
+template <typename T1>
 Vector<SCALAR> L1<SCALAR>::apply_soft_threshhold(Real gamma, Eigen::MatrixBase<T1> const &x) const {
   if (weights().size() == 1)
     return soft_threshhold(x, gamma * weights()(0));
@@ -376,8 +376,8 @@ Vector<SCALAR> L1<SCALAR>::apply_soft_threshhold(Real gamma, Eigen::MatrixBase<T
     return soft_threshhold(x, gamma * weights());
 }
 
-template <class SCALAR>
-template <class T0, class T1>
+template <typename SCALAR>
+template <typename T0, typename T1>
 void L1<SCALAR>::apply_constraints(Eigen::MatrixBase<T0> &out,
                                    Eigen::MatrixBase<T1> const &x) const {
   if (positivity_constraint())
@@ -388,12 +388,12 @@ void L1<SCALAR>::apply_constraints(Eigen::MatrixBase<T0> &out,
     out = x;
 }
 
-template <class SCALAR>
+template <typename SCALAR>
 class L1<SCALAR>::FistaMixing {
  public:
   using Real = typename real_type<SCALAR>::type;
   FistaMixing() : t(1){};
-  template <class T1>
+  template <typename T1>
   void operator()(Vector<SCALAR> &previous, Eigen::MatrixBase<T1> const &unmixed, t_uint iter) {
     // reset
     if (iter == 0) {
@@ -412,16 +412,16 @@ class L1<SCALAR>::FistaMixing {
   Real t;
 };
 
-template <class SCALAR>
+template <typename SCALAR>
 class L1<SCALAR>::NoMixing {
  public:
-  template <class T1>
+  template <typename T1>
   void operator()(Vector<SCALAR> &previous, Eigen::MatrixBase<T1> const &unmixed, t_uint) {
     previous = unmixed;
   }
 };
 
-template <class SCALAR>
+template <typename SCALAR>
 class L1<SCALAR>::Breaker {
  public:
   using Real = typename real_type<SCALAR>::type;

--- a/cpp/sopt/l2_forward_backward.h
+++ b/cpp/sopt/l2_forward_backward.h
@@ -20,7 +20,7 @@
 #endif
 
 namespace sopt::algorithm {
-template <class SCALAR>
+template <typename SCALAR>
 class L2ForwardBackward {
   //! Underlying algorithm
   using FB = ForwardBackward<SCALAR>;
@@ -31,7 +31,7 @@ class L2ForwardBackward {
   using Real = typename FB::Real;
   using t_Vector = typename FB::t_Vector;
   using t_LinearTransform = typename FB::t_LinearTransform;
-  template <class T>
+  template <typename T>
   using t_Proximal = std::function<void(t_Vector &, const T &, const t_Vector &)>;
   using t_Gradient = typename FB::t_Gradient;
   using t_IsConverged = typename FB::t_IsConverged;
@@ -51,7 +51,7 @@ class L2ForwardBackward {
   //! Setups imaging wrapper for ForwardBackward
   //! \param[in] f_proximal: proximal operator of the \f$f\f$ function.
   //! \param[in] g_proximal: proximal operator of the \f$g\f$ function
-  template <class DERIVED>
+  template <typename DERIVED>
   L2ForwardBackward(Eigen::MatrixBase<DERIVED> const &target)
       : l2_proximal_([](t_Vector &output, const t_real &gamma, const t_Vector &x) -> void {
           proximal::l2_norm(output, gamma, x);
@@ -140,7 +140,7 @@ class L2ForwardBackward {
   //! Minimun of objective_function
   Real objmin() const { return objmin_; }
   //! Sets the vector of target measurements
-  template <class DERIVED>
+  template <typename DERIVED>
   L2ForwardBackward<Scalar> &target(Eigen::MatrixBase<DERIVED> const &target) {
     target_ = target;
     return *this;
@@ -193,7 +193,7 @@ class L2ForwardBackward {
   }
 
   //! Set Φ and Φ^† using arguments that sopt::linear_transform understands
-  template <class... ARGS>
+  template <typename... ARGS>
   typename std::enable_if<sizeof...(ARGS) >= 1, L2ForwardBackward &>::type Phi(
       ARGS &&... args) {
     Phi_ = linear_transform(std::forward<ARGS>(args)...);
@@ -251,7 +251,7 @@ class L2ForwardBackward {
                     t_Vector const &residual) const;
 };
 
-template <class SCALAR>
+template <typename SCALAR>
 typename L2ForwardBackward<SCALAR>::Diagnostic L2ForwardBackward<SCALAR>::operator()(
     t_Vector &out, t_Vector const &guess, t_Vector const &res) const {
   SOPT_HIGH_LOG("Performing Forward Backward with L2 and L2 norms");
@@ -286,7 +286,7 @@ typename L2ForwardBackward<SCALAR>::Diagnostic L2ForwardBackward<SCALAR>::operat
   return result;
 }
 
-template <class SCALAR>
+template <typename SCALAR>
 bool L2ForwardBackward<SCALAR>::residual_convergence(t_Vector const &x,
                                                           t_Vector const &residual) const {
   if (static_cast<bool>(residual_convergence())) return residual_convergence()(x, residual);
@@ -296,7 +296,7 @@ bool L2ForwardBackward<SCALAR>::residual_convergence(t_Vector const &x,
   return residual_norm < residual_tolerance();
 }
 
-template <class SCALAR>
+template <typename SCALAR>
 bool L2ForwardBackward<SCALAR>::objective_convergence(ScalarRelativeVariation<Scalar> &scalvar,
                                                            t_Vector const &x,
                                                            t_Vector const &residual) const {
@@ -308,7 +308,7 @@ bool L2ForwardBackward<SCALAR>::objective_convergence(ScalarRelativeVariation<Sc
 }
 
 #ifdef SOPT_MPI
-template <class SCALAR>
+template <typename SCALAR>
 bool L2ForwardBackward<SCALAR>::objective_convergence(mpi::Communicator const &obj_comm,
                                                            ScalarRelativeVariation<Scalar> &scalvar,
                                                            t_Vector const &x,
@@ -322,7 +322,7 @@ bool L2ForwardBackward<SCALAR>::objective_convergence(mpi::Communicator const &o
 }
 #endif
 
-template <class SCALAR>
+template <typename SCALAR>
 bool L2ForwardBackward<SCALAR>::is_converged(ScalarRelativeVariation<Scalar> &scalvar,
                                                   t_Vector const &x,
                                                   t_Vector const &residual) const {

--- a/cpp/sopt/l2_primal_dual.h
+++ b/cpp/sopt/l2_primal_dual.h
@@ -15,7 +15,7 @@
 #include "sopt/types.h"
 
 namespace sopt::algorithm {
-template <class SCALAR>
+template <typename SCALAR>
 class ImagingPrimalDual {
   //! Underlying algorithm
   using PD = PrimalDual<SCALAR>;
@@ -26,7 +26,7 @@ class ImagingPrimalDual {
   using Real = typename PD::Real;
   using t_Vector = typename PD::t_Vector;
   using t_LinearTransform = typename PD::t_LinearTransform;
-  template <class T>
+  template <typename T>
   using t_Proximal = std::function<void(t_Vector &, const T &, const t_Vector &)>;
   using t_IsConverged = typename PD::t_IsConverged;
   using t_Constraint = typename PD::t_Constraint;
@@ -47,7 +47,7 @@ class ImagingPrimalDual {
   //! Setups imaging wrapper for PD
   //! \param[in] f_proximal: proximal operator of the \f$f\f$ function.
   //! \param[in] g_proximal: proximal operator of the \f$g\f$ function
-  template <class DERIVED>
+  template <typename DERIVED>
   ImagingPrimalDual(Eigen::MatrixBase<DERIVED> const &target)
       : l2_proximal_([](t_Vector &out, const Real &gamma, const t_Vector &x) {
           proximal::l2_norm(out, gamma, x);
@@ -160,7 +160,7 @@ class ImagingPrimalDual {
   //! Vector of target measurements
   t_Vector const &target() const { return target_; }
   //! Sets the vector of target measurements
-  template <class DERIVED>
+  template <typename DERIVED>
   ImagingPrimalDual<Scalar> &target(Eigen::MatrixBase<DERIVED> const &target) {
     target_ = target;
     return *this;
@@ -213,7 +213,7 @@ class ImagingPrimalDual {
   }
 
   //! Set Φ and Φ^† using arguments that sopt::linear_transform understands
-  template <class... ARGS>
+  template <typename... ARGS>
   typename std::enable_if<sizeof...(ARGS) >= 1, ImagingPrimalDual &>::type Phi(ARGS &&... args) {
     Phi_ = linear_transform(std::forward<ARGS>(args)...);
     return *this;
@@ -224,7 +224,7 @@ class ImagingPrimalDual {
   proximal::WeightedL2Ball<Scalar> &l2ball_proximal() { return l2ball_proximal_; }
 
   //! Analysis operator Ψ
-  template <class... ARGS>
+  template <typename... ARGS>
   typename std::enable_if<sizeof...(ARGS) >= 1, ImagingPrimalDual &>::type Psi(ARGS &&... args) {
     Psi_ = linear_transform(std::forward<ARGS>(args)...);
     return *this;
@@ -299,7 +299,7 @@ class ImagingPrimalDual {
   }
 };
 
-template <class SCALAR>
+template <typename SCALAR>
 typename ImagingPrimalDual<SCALAR>::Diagnostic ImagingPrimalDual<SCALAR>::operator()(
     t_Vector &out, t_Vector const &guess, t_Vector const &res) const {
   SOPT_HIGH_LOG("Performing Primal Dual with L1 and L2 operators");
@@ -362,7 +362,7 @@ typename ImagingPrimalDual<SCALAR>::Diagnostic ImagingPrimalDual<SCALAR>::operat
   return result;
 }
 
-template <class SCALAR>
+template <typename SCALAR>
 bool ImagingPrimalDual<SCALAR>::residual_convergence(t_Vector const &x,
                                                      t_Vector const &residual) const {
   if (static_cast<bool>(residual_convergence())) return residual_convergence()(x, residual);
@@ -372,7 +372,7 @@ bool ImagingPrimalDual<SCALAR>::residual_convergence(t_Vector const &x,
   return residual_norm < residual_tolerance();
 }
 
-template <class SCALAR>
+template <typename SCALAR>
 bool ImagingPrimalDual<SCALAR>::objective_convergence(ScalarRelativeVariation<Scalar> &scalvar,
                                                       t_Vector const &x,
                                                       t_Vector const &residual) const {
@@ -385,7 +385,7 @@ bool ImagingPrimalDual<SCALAR>::objective_convergence(ScalarRelativeVariation<Sc
   return scalvar(current);
 }
 
-template <class SCALAR>
+template <typename SCALAR>
 bool ImagingPrimalDual<SCALAR>::is_converged(ScalarRelativeVariation<Scalar> &scalvar,
                                              t_Vector const &x, t_Vector const &residual) const {
   auto const user = static_cast<bool>(is_converged()) == false or is_converged()(x, residual);

--- a/cpp/sopt/linear_transform.h
+++ b/cpp/sopt/linear_transform.h
@@ -18,15 +18,15 @@ namespace details {
 //! \brief Wraps a matrix into a function and its conjugate transpose
 //! \details This class helps to wrap matrices into functions, such that we can use and store them
 //! such that SDMM algorithms can refer to them.
-template <class EIGEN>
+template <typename EIGEN>
 class MatrixToLinearTransform;
 //! Wraps a tranposed matrix into a function and its conjugate transpose
-template <class EIGEN>
+template <typename EIGEN>
 class MatrixAdjointToLinearTransform;
 }  // namespace details
 
 //! Joins together direct and indirect operators
-template <class VECTOR>
+template <typename VECTOR>
 class LinearTransform : public details::WrapFunction<VECTOR> {
  public:
   //! Type of the wrapped functions
@@ -97,7 +97,7 @@ class LinearTransform : public details::WrapFunction<VECTOR> {
 //! \param[in] sizes: 3 integer elements (a, b, c) such that if the input to linear operator is
 //!     of size N, then the output is of size (a * N) / b + c. A similar quantity is deduced for
 //!     the indirect operator.
-template <class VECTOR>
+template <typename VECTOR>
 LinearTransform<VECTOR> linear_transform(OperatorFunction<VECTOR> const &direct,
                                          OperatorFunction<VECTOR> const &indirect,
                                          std::array<t_int, 3> const &sizes = {{1, 1, 0}}) {
@@ -112,7 +112,7 @@ LinearTransform<VECTOR> linear_transform(OperatorFunction<VECTOR> const &direct,
 //!    the conjugate transpose linear operator to a vector.
 //! \param[in] dsizes: 3 integer elements (a, b, c) such that if the input to the indirect
 //!    linear operator is of size N, then the output is of size (a * N) / b + c.
-template <class VECTOR>
+template <typename VECTOR>
 LinearTransform<VECTOR> linear_transform(OperatorFunction<VECTOR> const &direct,
                                          std::array<t_int, 3> const &dsizes,
                                          OperatorFunction<VECTOR> const &indirect,
@@ -121,12 +121,12 @@ LinearTransform<VECTOR> linear_transform(OperatorFunction<VECTOR> const &direct,
 }
 
 //! Convenience no-op function
-template <class VECTOR>
+template <typename VECTOR>
 LinearTransform<VECTOR> &linear_transform(LinearTransform<VECTOR> &passthrough) {
   return passthrough;
 }
 //! Creates a linear transform from a pair of wrappers
-template <class VECTOR>
+template <typename VECTOR>
 LinearTransform<VECTOR> linear_transform(details::WrapFunction<VECTOR> const &direct,
                                          details::WrapFunction<VECTOR> const &adjoint) {
   return {direct, adjoint};
@@ -134,7 +134,7 @@ LinearTransform<VECTOR> linear_transform(details::WrapFunction<VECTOR> const &di
 
 namespace details {
 
-template <class EIGEN>
+template <typename EIGEN>
 class MatrixToLinearTransform {
   //! The underlying raw matrix type
   using Raw = typename std::remove_const<typename std::remove_reference<EIGEN>::type>::type;
@@ -150,7 +150,7 @@ class MatrixToLinearTransform {
   //! \brief Creates from an expression
   //! \details Expression is evaluated and the result stored internally. This object owns a
   //! copy of the matrix. It might share it with a few friendly neighbors.
-  template <class T0>
+  template <typename T0>
   MatrixToLinearTransform(Eigen::MatrixBase<T0> const &A) : matrix(std::make_shared<EIGEN>(A)) {}
   //! Creates from a shared matrix.
   MatrixToLinearTransform(std::shared_ptr<EIGEN> const &x) : matrix(x){}
@@ -175,14 +175,14 @@ class MatrixToLinearTransform {
   std::shared_ptr<EIGEN> matrix;
 };
 
-template <class EIGEN>
+template <typename EIGEN>
 class MatrixAdjointToLinearTransform {
  public:
   using PlainObject = typename MatrixToLinearTransform<EIGEN>::PlainObject;
   //! \brief Creates from an expression
   //! \details Expression is evaluated and the result stored internally. This object owns a
   //! copy of the matrix. It might share it with a few friendly neighbors.
-  template <class T0>
+  template <typename T0>
   MatrixAdjointToLinearTransform(Eigen::MatrixBase<T0> const &A)
       : matrix(std::make_shared<EIGEN>(A)) {}
   //! Creates from a shared matrix.
@@ -207,7 +207,7 @@ class MatrixAdjointToLinearTransform {
 }  // namespace details
 
 //! Helper function to creates a function operator
-template <class DERIVED>
+template <typename DERIVED>
 LinearTransform<Vector<typename DERIVED::Scalar>> linear_transform(
     Eigen::MatrixBase<DERIVED> const &A) {
   details::MatrixToLinearTransform<Matrix<typename DERIVED::Scalar>> const matrix(A);
@@ -222,7 +222,7 @@ LinearTransform<Vector<typename DERIVED::Scalar>> linear_transform(
 }
 
 //! Helper function to create a linear transform that's just the identity
-template <class SCALAR>
+template <typename SCALAR>
 LinearTransform<Vector<SCALAR>> linear_transform_identity() {
   return {[](Vector<SCALAR> &out, Vector<SCALAR> const &in) { out = in; },
           [](Vector<SCALAR> &out, Vector<SCALAR> const &in) { out = in; }};

--- a/cpp/sopt/maths.h
+++ b/cpp/sopt/maths.h
@@ -12,18 +12,18 @@
 namespace sopt {
 
 //! Computes the standard deviation of a vector
-template <class T>
+template <typename T>
 typename real_type<typename T::Scalar>::type standard_deviation(Eigen::ArrayBase<T> const &x) {
   return (x - x.mean()).matrix().stableNorm() / std::sqrt(x.size());
 }
 //! Computes the standard deviation of a vector
-template <class T>
+template <typename T>
 typename real_type<typename T::Scalar>::type standard_deviation(Eigen::MatrixBase<T> const &x) {
   return standard_deviation(x.array());
 }
 
 //! abs(x) < threshhold ? 0: x - sgn(x) * threshhold
-template <class SCALAR>
+template <typename SCALAR>
 typename std::enable_if<std::is_arithmetic<SCALAR>::value or is_complex<SCALAR>::value,
                         SCALAR>::type
 soft_threshhold(SCALAR const &x, typename real_type<SCALAR>::type const &threshhold) {
@@ -33,13 +33,13 @@ soft_threshhold(SCALAR const &x, typename real_type<SCALAR>::type const &threshh
 
 namespace details {
 //! Expression to create projection onto positive orthant
-template <class SCALAR>
+template <typename SCALAR>
 class ProjectPositiveQuadrant {
  public:
   SCALAR operator()(const SCALAR &value) const { return std::max(value, SCALAR(0)); }
 };
 //! Specialization for complex numbers
-template <class SCALAR>
+template <typename SCALAR>
 class ProjectPositiveQuadrant<std::complex<SCALAR>> {
  public:
   SCALAR operator()(SCALAR const &value) const { return std::max(value, SCALAR(0)); }
@@ -49,13 +49,13 @@ class ProjectPositiveQuadrant<std::complex<SCALAR>> {
 };
 
 //! Helper template type alias to instantiate soft_threshhold that takes an Eigen object
-template <class SCALAR>
+template <typename SCALAR>
 using SoftThreshhold = decltype(std::bind(soft_threshhold<SCALAR>, std::placeholders::_1,
                                           typename real_type<SCALAR>::type(1)));
 }  // namespace details
 
 //! Expression to create projection onto positive quadrant
-template <class T>
+template <typename T>
 Eigen::CwiseUnaryOp<const details::ProjectPositiveQuadrant<typename T::Scalar>, const T>
 positive_quadrant(Eigen::DenseBase<T> const &input) {
   using Projector = details::ProjectPositiveQuadrant<typename T::Scalar>;
@@ -64,7 +64,7 @@ positive_quadrant(Eigen::DenseBase<T> const &input) {
 }
 
 //! Expression to create soft-threshhold
-template <class T>
+template <typename T>
 Eigen::CwiseUnaryOp<const details::SoftThreshhold<typename T::Scalar>, const T> soft_threshhold(
     Eigen::DenseBase<T> const &input,
     typename real_type<typename T::Scalar>::type const &threshhold) {
@@ -78,7 +78,7 @@ Eigen::CwiseUnaryOp<const details::SoftThreshhold<typename T::Scalar>, const T> 
 //! \details Operates over a vector of threshholds: ``out(i) = soft_threshhold(x(i), h(i))``
 //! Threshhold and input vectors must have the same size and type. The latter condition is enforced
 //! by CwiseBinaryOp, unfortunately.
-template <class T0, class T1>
+template <typename T0, typename T1>
 typename std::enable_if<std::is_arithmetic<typename T0::Scalar>::value and
                             std::is_arithmetic<typename T1::Scalar>::value,
                         Eigen::CwiseBinaryOp<typename T0::Scalar (*)(typename T0::Scalar const &,
@@ -94,7 +94,7 @@ soft_threshhold(Eigen::DenseBase<T0> const &input, Eigen::DenseBase<T1> const &t
 //! \details Operates over a vector of threshholds: ``out(i) = soft_threshhold(x(i), h(i))``
 //! Threshhold and input vectors must have the same size and type. The latter condition is enforced
 //! by CwiseBinaryOp, unfortunately. So we cast threshhold from real to complex and back.
-template <class T0, class T1>
+template <typename T0, typename T1>
 typename std::enable_if<
     is_complex<typename T0::Scalar>::value and std::is_arithmetic<typename T1::Scalar>::value,
     Eigen::CwiseBinaryOp<
@@ -112,51 +112,51 @@ soft_threshhold(Eigen::DenseBase<T0> const &input, Eigen::DenseBase<T1> const &t
 }
 
 //! Computes weighted L1 norm
-template <class T0, class T1>
+template <typename T0, typename T1>
 typename real_type<typename T0::Scalar>::type l1_norm(Eigen::ArrayBase<T0> const &input,
                                                       Eigen::ArrayBase<T1> const &weights) {
   if (weights.size() == 1) return input.cwiseAbs().sum() * std::abs(weights(0));
   return (input * weights).cwiseAbs().sum();
 }
 //! Computes weighted L1 norm
-template <class T0, class T1>
+template <typename T0, typename T1>
 typename real_type<typename T0::Scalar>::type l1_norm(Eigen::MatrixBase<T0> const &input,
                                                       Eigen::MatrixBase<T1> const &weight) {
   return l1_norm(input.array(), weight.array());
 }
 //! Computes L1 norm
-template <class T0>
+template <typename T0>
 typename real_type<typename T0::Scalar>::type l1_norm(Eigen::ArrayBase<T0> const &input) {
   return input.cwiseAbs().sum();
 }
 //! Computes L1 norm
-template <class T0>
+template <typename T0>
 typename real_type<typename T0::Scalar>::type l1_norm(Eigen::MatrixBase<T0> const &input) {
   return l1_norm(input.array());
 }
 
 //! Computes weighted L2 norm
-template <class T0, class T1>
+template <typename T0, typename T1>
 typename real_type<typename T0::Scalar>::type l2_norm(Eigen::ArrayBase<T0> const &input,
                                                       Eigen::ArrayBase<T1> const &weights) {
   if (weights.size() == 1) return input.matrix().stableNorm() * std::abs(weights(0));
   return (input * weights).matrix().stableNorm();
 }
 //! Computes weighted L2 norm
-template <class T0, class T1>
+template <typename T0, typename T1>
 typename real_type<typename T0::Scalar>::type l2_norm(Eigen::MatrixBase<T0> const &input,
                                                       Eigen::MatrixBase<T1> const &weights) {
   return l2_norm(input.derived().array(), weights.derived().array());
 }
 //! Computes weighted L2 norm
-template <class T0>
+template <typename T0>
 typename real_type<typename T0::Scalar>::type l2_norm(Eigen::ArrayBase<T0> const &input) {
   typename T0::PlainObject w(1);
   w(0) = 1;
   return l2_norm(input, w);
 }
 //! Computes weighted L2 norm
-template <class T0>
+template <typename T0>
 typename real_type<typename T0::Scalar>::type l2_norm(Eigen::MatrixBase<T0> const &input) {
   typename T0::PlainObject w(1);
   w(0) = 1;
@@ -164,7 +164,7 @@ typename real_type<typename T0::Scalar>::type l2_norm(Eigen::MatrixBase<T0> cons
 }
 
 //! Computes weighted TV norm
-template <class T0, class T1>
+template <typename T0, typename T1>
 typename real_type<typename T0::Scalar>::type tv_norm(Eigen::ArrayBase<T0> const &input,
                                                       Eigen::ArrayBase<T1> const &weights) {
   const auto size = input.size() / 2;
@@ -182,20 +182,20 @@ typename real_type<typename T0::Scalar>::type tv_norm(Eigen::ArrayBase<T0> const
           .sum());
 }
 //! Computes weighted TV norm
-template <class T0, class T1>
+template <typename T0, typename T1>
 typename real_type<typename T0::Scalar>::type tv_norm(Eigen::MatrixBase<T0> const &input,
                                                       Eigen::MatrixBase<T1> const &weights) {
   return tv_norm(input.derived().array(), weights.derived().array());
 }
 //! Computes weighted tv norm
-template <class T0>
+template <typename T0>
 typename real_type<typename T0::Scalar>::type tv_norm(Eigen::ArrayBase<T0> const &input) {
   typename T0::PlainObject w(1);
   w(0) = 1;
   return tv_norm(input, w);
 }
 //! Computes weighted TV norm
-template <class T0>
+template <typename T0>
 typename real_type<typename T0::Scalar>::type tv_norm(Eigen::MatrixBase<T0> const &input) {
   typename T0::PlainObject w(1);
   w(0) = 1;

--- a/cpp/sopt/mpi/communicator.h
+++ b/cpp/sopt/mpi/communicator.h
@@ -71,12 +71,12 @@ class Communicator {
   void abort(const std::string &reason) const;
 
   //! Helper function for reducing
-  template <class T>
+  template <typename T>
   typename std::enable_if<is_registered_type<T>::value, T>::type all_reduce(T const &value,
                                                                             MPI_Op operation) const;
 
   //! In-place reduction over an image
-  template <class T>
+  template <typename T>
   typename std::enable_if<is_registered_type<T>::value>::type all_reduce(Matrix<T> &image,
                                                                          MPI_Op operation) const {
     if (size() == 1) return;
@@ -84,7 +84,7 @@ class Communicator {
     MPI_Allreduce(MPI_IN_PLACE, image.data(), image.size(), registered_type(T(0)), operation,
                   **this);
   }
-  template <class T>
+  template <typename T>
   typename std::enable_if<is_registered_type<T>::value>::type all_reduce(Image<T> &image,
                                                                          MPI_Op operation) const {
     if (size() == 1) return;
@@ -92,7 +92,7 @@ class Communicator {
     MPI_Allreduce(MPI_IN_PLACE, image.data(), image.size(), registered_type(T(0)), operation,
                   **this);
   }
-  template <class T>
+  template <typename T>
   typename std::enable_if<is_registered_type<T>::value>::type all_reduce(Vector<T> &image,
                                                                          MPI_Op operation) const {
     if (size() == 1) return;
@@ -102,16 +102,16 @@ class Communicator {
   }
 
   //! Helper function for reducing through sum
-  template <class T>
+  template <typename T>
   typename std::enable_if<is_registered_type<T>::value, T>::type all_sum_all(T const &value) const {
     return all_reduce(value, MPI_SUM);
   }
-  template <class T>
+  template <typename T>
   typename std::enable_if<is_registered_type<typename T::Scalar>::value>::type all_sum_all(
       T &image) const {
     all_reduce(image, MPI_SUM);
   }
-  template <class T>
+  template <typename T>
   typename std::enable_if<is_registered_type<typename T::Scalar>::value, T>::type all_sum_all(
       T const &image) const {
     T result(image);
@@ -120,25 +120,25 @@ class Communicator {
   }
 
   //! Broadcasts object
-  template <class T>
+  template <typename T>
   typename std::enable_if<is_registered_type<T>::value, T>::type broadcast(
       T const &value, t_uint const root = root_id()) const;
   //! Receive broadcast object
-  template <class T>
+  template <typename T>
   typename std::enable_if<is_registered_type<T>::value, T>::type broadcast(
       t_uint const root = root_id()) const;
-  template <class T>
+  template <typename T>
   typename std::enable_if<is_registered_type<typename T::Scalar>::value, T>::type broadcast(
       T const &vec, t_uint const root = root_id()) const;
-  template <class T>
+  template <typename T>
   typename std::enable_if<is_registered_type<typename T::Scalar>::value, T>::type broadcast(
       t_uint const root = root_id()) const;
-  template <class T>
+  template <typename T>
   typename std::enable_if<is_registered_type<typename T::value_type>::value and
                               not std::is_base_of<Eigen::EigenBase<T>, T>::value,
                           T>::type
   broadcast(T const &vec, t_uint const root = root_id()) const;
-  template <class T>
+  template <typename T>
   typename std::enable_if<is_registered_type<typename T::value_type>::value and
                               not std::is_base_of<Eigen::EigenBase<T>, T>::value,
                           T>::type
@@ -146,69 +146,69 @@ class Communicator {
   std::string broadcast(std::string const &input, t_uint const root = root_id()) const;
 
   //! Scatter one object per proc
-  template <class T>
+  template <typename T>
   typename std::enable_if<is_registered_type<T>::value, T>::type scatter_one(
       std::vector<T> const &values, t_uint const root = root_id()) const;
   //! Receive scattered objects
-  template <class T>
+  template <typename T>
   typename std::enable_if<is_registered_type<T>::value, T>::type scatter_one(
       t_uint const root = root_id()) const;
 
   //! Scatter
-  template <class T>
+  template <typename T>
   typename std::enable_if<is_registered_type<T>::value, Vector<T>>::type scatterv(
       Vector<T> const &vec, std::vector<t_int> const &sizes, t_uint const root = root_id()) const;
-  template <class T>
+  template <typename T>
   typename std::enable_if<is_registered_type<T>::value, Vector<T>>::type scatterv(
       t_int local_size, t_uint const root = root_id()) const;
 
   // Gather one object per proc
-  template <class T>
+  template <typename T>
   typename std::enable_if<is_registered_type<T>::value, std::vector<T>>::type gather(
       T const value, t_uint const root = root_id()) const;
 
   //! Gather
-  template <class T>
+  template <typename T>
   typename std::enable_if<is_registered_type<T>::value, Vector<T>>::type gather(
       Vector<T> const &vec, std::vector<t_int> const &sizes, t_uint const root = root_id()) const {
     return gather_<Vector<T>, T>(vec, sizes, root);
   }
-  template <class T>
+  template <typename T>
   typename std::enable_if<is_registered_type<T>::value, Vector<T>>::type gather(
       Vector<T> const &vec, t_uint const root = root_id()) const {
     return gather_<Vector<T>, T>(vec, root);
   }
 
-  template <class T>
+  template <typename T>
   typename std::enable_if<is_registered_type<T>::value, std::set<T>>::type gather(
       std::set<T> const &set, std::vector<t_int> const &sizes, t_uint const root = root_id()) const;
-  template <class T>
+  template <typename T>
   typename std::enable_if<is_registered_type<T>::value, std::set<T>>::type gather(
       std::set<T> const &vec, t_uint const root = root_id()) const;
-  template <class T>
+  template <typename T>
   typename std::enable_if<is_registered_type<T>::value, std::vector<T>>::type gather(
       std::vector<T> const &vec, std::vector<t_int> const &sizes,
       t_uint const root = root_id()) const {
     return gather_<std::vector<T>, T>(vec, sizes, root);
   }
-  template <class T>
+  template <typename T>
   typename std::enable_if<is_registered_type<T>::value, std::vector<T>>::type gather(
       std::vector<T> const &vec, t_uint const root = root_id()) const {
     return gather_<std::vector<T>, T>(vec, root);
   }
   //! All to all
-  template <class T>
+  template <typename T>
   typename std::enable_if<is_registered_type<T>::value, Vector<T>>::type all_to_allv(
       const Vector<T> &vec, std::vector<t_int> const &send_sizes) const;
-  template <class T>
+  template <typename T>
   typename std::enable_if<is_registered_type<T>::value, Vector<T>>::type all_to_allv(
       const Vector<T> &vec, std::vector<t_int> const &send_sizes,
       std::vector<t_int> const &rec_sizes) const;
-  template <class T>
+  template <typename T>
   typename std::enable_if<is_registered_type<T>::value, std::vector<T>>::type all_to_allv(
       const std::vector<T> &vec, std::vector<t_int> const &send_sizes,
       std::vector<t_int> const &rec_sizes) const;
-  template <class T>
+  template <typename T>
   typename std::enable_if<is_registered_type<T>::value, std::vector<T>>::type all_to_allv(
       const std::vector<T> &vec, std::vector<t_int> const &send_sizes) const;
 
@@ -246,14 +246,14 @@ class Communicator {
   Communicator(MPI_Comm const &comm);
 
   //! Gather
-  template <class CONTAINER, class T>
+  template <typename CONTAINER, typename T>
   CONTAINER gather_(CONTAINER const &vec, std::vector<t_int> const &sizes,
                     t_uint const root = root_id()) const;
-  template <class CONTAINER, class T>
+  template <typename CONTAINER, typename T>
   CONTAINER gather_(CONTAINER const &vec, t_uint const root = root_id()) const;
 };
 
-template <class T>
+template <typename T>
 typename std::enable_if<is_registered_type<T>::value, T>::type Communicator::all_reduce(
     T const &value, MPI_Op operation) const {
   if (size() == 1) return value;
@@ -264,7 +264,7 @@ typename std::enable_if<is_registered_type<T>::value, T>::type Communicator::all
   return result;
 }
 
-template <class T>
+template <typename T>
 typename std::enable_if<is_registered_type<T>::value, T>::type Communicator::scatter_one(
     std::vector<T> const &values, t_uint const root) const {
   assert(root < size());
@@ -276,7 +276,7 @@ typename std::enable_if<is_registered_type<T>::value, T>::type Communicator::sca
   return result;
 }
 //! Receive scattered objects
-template <class T>
+template <typename T>
 typename std::enable_if<is_registered_type<T>::value, T>::type Communicator::scatter_one(
     t_uint const root) const {
   T result;
@@ -285,7 +285,7 @@ typename std::enable_if<is_registered_type<T>::value, T>::type Communicator::sca
   return result;
 }
 
-template <class T>
+template <typename T>
 typename std::enable_if<is_registered_type<T>::value, Vector<T>>::type Communicator::scatterv(
     Vector<T> const &vec, std::vector<t_int> const &sizes, t_uint const root) const {
   if (size() == 1) {
@@ -313,7 +313,7 @@ typename std::enable_if<is_registered_type<T>::value, Vector<T>>::type Communica
   return result;
 }
 
-template <class T>
+template <typename T>
 typename std::enable_if<is_registered_type<T>::value, Vector<T>>::type Communicator::scatterv(
     t_int local_size, t_uint const root) const {
   if (rank() == root) throw std::runtime_error("Root should call the *other* scatterv");
@@ -325,7 +325,7 @@ typename std::enable_if<is_registered_type<T>::value, Vector<T>>::type Communica
   return result;
 }
 
-template <class T>
+template <typename T>
 typename std::enable_if<is_registered_type<T>::value, std::vector<T>>::type
 Communicator::all_to_allv(const std::vector<T> &vec, std::vector<t_int> const &send_sizes) const {
   if (size() == 1) {
@@ -343,7 +343,7 @@ Communicator::all_to_allv(const std::vector<T> &vec, std::vector<t_int> const &s
 
   return all_to_allv<T>(vec, send_sizes, rec_sizes);
 }
-template <class T>
+template <typename T>
 typename std::enable_if<is_registered_type<T>::value, std::vector<T>>::type
 Communicator::all_to_allv(const std::vector<T> &vec, std::vector<t_int> const &send_sizes,
                           std::vector<t_int> const &rec_sizes) const {
@@ -374,7 +374,7 @@ Communicator::all_to_allv(const std::vector<T> &vec, std::vector<t_int> const &s
   return output;
 }
 
-template <class T>
+template <typename T>
 typename std::enable_if<is_registered_type<T>::value, Vector<T>>::type Communicator::all_to_allv(
     const Vector<T> &vec, std::vector<t_int> const &send_sizes) const {
   if (size() == 1) {
@@ -393,7 +393,7 @@ typename std::enable_if<is_registered_type<T>::value, Vector<T>>::type Communica
   return all_to_allv<T>(vec, send_sizes, rec_sizes);
 }
 
-template <class T>
+template <typename T>
 typename std::enable_if<is_registered_type<T>::value, Vector<T>>::type Communicator::all_to_allv(
     const Vector<T> &vec, std::vector<t_int> const &send_sizes,
     std::vector<t_int> const &rec_sizes) const {
@@ -424,7 +424,7 @@ typename std::enable_if<is_registered_type<T>::value, Vector<T>>::type Communica
   return output;
 }
 
-template <class T>
+template <typename T>
 typename std::enable_if<is_registered_type<T>::value, std::vector<T>>::type Communicator::gather(
     T const value, t_uint const root) const {
   assert(root < size());
@@ -440,7 +440,7 @@ typename std::enable_if<is_registered_type<T>::value, std::vector<T>>::type Comm
   return result;
 }
 
-template <class CONTAINER, class T>
+template <typename CONTAINER, typename T>
 CONTAINER Communicator::gather_(CONTAINER const &vec, std::vector<t_int> const &sizes,
                                 t_uint const root) const {
   assert(root < size());
@@ -471,7 +471,7 @@ CONTAINER Communicator::gather_(CONTAINER const &vec, std::vector<t_int> const &
   return result;
 }
 
-template <class CONTAINER, class T>
+template <typename CONTAINER, typename T>
 CONTAINER Communicator::gather_(CONTAINER const &vec, t_uint const root) const {
   assert(root < size());
   if (rank() == root) throw std::runtime_error("Root should call the *other* gather");
@@ -481,7 +481,7 @@ CONTAINER Communicator::gather_(CONTAINER const &vec, t_uint const root) const {
   return CONTAINER();
 }
 
-template <class T>
+template <typename T>
 typename std::enable_if<is_registered_type<T>::value, std::set<T>>::type Communicator::gather(
     std::set<T> const &set, std::vector<t_int> const &sizes, t_uint const root) const {
   assert(root < size());
@@ -498,7 +498,7 @@ typename std::enable_if<is_registered_type<T>::value, std::set<T>>::type Communi
   return std::set<T>(buffer.data(), buffer.data() + buffer.size());
 }
 
-template <class T>
+template <typename T>
 typename std::enable_if<is_registered_type<T>::value, std::set<T>>::type Communicator::gather(
     std::set<T> const &set, t_uint const root) const {
   assert(root < size());
@@ -510,7 +510,7 @@ typename std::enable_if<is_registered_type<T>::value, std::set<T>>::type Communi
   return std::set<T>();
 }
 
-template <class T>
+template <typename T>
 typename std::enable_if<is_registered_type<T>::value, T>::type Communicator::broadcast(
     T const &value, t_uint const root) const {
   assert(root < size());
@@ -521,7 +521,7 @@ typename std::enable_if<is_registered_type<T>::value, T>::type Communicator::bro
   return result;
 }
 //! Receive broadcast object
-template <class T>
+template <typename T>
 typename std::enable_if<is_registered_type<T>::value, T>::type Communicator::broadcast(
     t_uint const root) const {
   assert(root < size());
@@ -532,7 +532,7 @@ typename std::enable_if<is_registered_type<T>::value, T>::type Communicator::bro
   return result;
 }
 
-template <class T>
+template <typename T>
 typename std::enable_if<is_registered_type<typename T::Scalar>::value, T>::type
 Communicator::broadcast(T const &vec, t_uint const root) const {
   if (size() == 1) return vec;
@@ -545,7 +545,7 @@ Communicator::broadcast(T const &vec, t_uint const root) const {
             root, **this);
   return vec;
 }
-template <class T>
+template <typename T>
 typename std::enable_if<is_registered_type<typename T::Scalar>::value, T>::type
 Communicator::broadcast(t_uint const root) const {
   assert(root < size());
@@ -557,7 +557,7 @@ Communicator::broadcast(t_uint const root) const {
   MPI_Bcast(result.data(), result.size(), Type<typename T::Scalar>::value, root, **this);
   return result;
 }
-template <class T>
+template <typename T>
 typename std::enable_if<is_registered_type<typename T::value_type>::value and
                             not std::is_base_of<Eigen::EigenBase<T>, T>::value,
                         T>::type
@@ -571,7 +571,7 @@ Communicator::broadcast(T const &vec, t_uint const root) const {
             Type<typename T::value_type>::value, root, **this);
   return vec;
 }
-template <class T>
+template <typename T>
 typename std::enable_if<is_registered_type<typename T::value_type>::value and
                             not std::is_base_of<Eigen::EigenBase<T>, T>::value,
                         T>::type

--- a/cpp/sopt/mpi/registered_types.h
+++ b/cpp/sopt/mpi/registered_types.h
@@ -13,7 +13,7 @@ using MPIType = decltype(MPI_CHAR);
 // using MPIType = int;
 
 //! MPI type associated with a c++ type
-template <class T>
+template <typename T>
 struct Type;
 
 static_assert(not std::is_same<char, std::int8_t>::value, "");
@@ -50,7 +50,7 @@ SOPT_MACRO(std::complex<long double>);
 #undef SOPT_MACRO
 
 //! MPI type associated with a c++ type
-template <class T>
+template <typename T>
 inline constexpr MPIType registered_type(T const &) {
   return Type<T>::value;
 }
@@ -68,9 +68,9 @@ template <typename... Ts>
 using void_t = typename make_void<Ts...>::type;
 }  // namespace details
 //! True if the type is registered
-template <class T, class = details::void_t<>>
+template <typename T, typename = details::void_t<>>
 class is_registered_type : public std::false_type {};
-template <class T>
+template <typename T>
 class is_registered_type<T, details::void_t<decltype(Type<T>::value)>> : public std::true_type {};
 } // namespace sopt::mpi
 #endif

--- a/cpp/sopt/mpi/utilities.h
+++ b/cpp/sopt/mpi/utilities.h
@@ -11,14 +11,14 @@
 namespace sopt::mpi {
 
 //! Computes norm of distributed vector
-template <class T>
+template <typename T>
 typename real_type<typename T::Scalar>::type l2_norm(Eigen::MatrixBase<T> const &x,
                                                      Communicator const &comm) {
   return std::sqrt(comm.all_sum_all(x.squaredNorm()));
 }
 
 //! Weighted l2-norm over distributed data
-template <class T0, class T1>
+template <typename T0, typename T1>
 typename real_type<typename T0::Scalar>::type l2_norm(Eigen::ArrayBase<T0> const &input,
                                                       Eigen::ArrayBase<T1> const &weights,
                                                       Communicator const &comm) {
@@ -29,7 +29,7 @@ typename real_type<typename T0::Scalar>::type l2_norm(Eigen::ArrayBase<T0> const
   return sopt::mpi::l2_norm((input * weights).matrix(), comm);
 }
 //! Weighted l2-norm over distributed data
-template <class T0, class T1>
+template <typename T0, typename T1>
 typename real_type<typename T0::Scalar>::type l2_norm(Eigen::MatrixBase<T0> const &input,
                                                       Eigen::MatrixBase<T1> const &weights,
                                                       Communicator const &comm) {
@@ -37,27 +37,27 @@ typename real_type<typename T0::Scalar>::type l2_norm(Eigen::MatrixBase<T0> cons
 }
 
 //! Computes weighted L1 norm
-template <class T0, class T1>
+template <typename T0, typename T1>
 typename real_type<typename T0::Scalar>::type l1_norm(Eigen::ArrayBase<T0> const &input,
                                                       Eigen::ArrayBase<T1> const &weights,
                                                       Communicator const &comm) {
   return comm.all_sum_all(sopt::l1_norm(input, weights));
 }
 //! Computes weighted L1 norm
-template <class T0, class T1>
+template <typename T0, typename T1>
 typename real_type<typename T0::Scalar>::type l1_norm(Eigen::MatrixBase<T0> const &input,
                                                       Eigen::MatrixBase<T1> const &weights,
                                                       Communicator const &comm) {
   return comm.all_sum_all(sopt::l1_norm(input, weights));
 }
 //! Computes L1 norm
-template <class T0>
+template <typename T0>
 typename real_type<typename T0::Scalar>::type l1_norm(Eigen::ArrayBase<T0> const &input,
                                                       Communicator const &comm) {
   return comm.all_sum_all(sopt::l1_norm(input));
 }
 //! Computes L1 norm
-template <class T0>
+template <typename T0>
 typename real_type<typename T0::Scalar>::type l1_norm(Eigen::MatrixBase<T0> const &input,
                                                       Communicator const &comm) {
   return comm.all_sum_all(sopt::l1_norm(input));

--- a/cpp/sopt/objective_functions.h
+++ b/cpp/sopt/objective_functions.h
@@ -11,21 +11,21 @@
 
 namespace sopt::objective_functions {
 //! returns g(x) + ||y - Φ x||_2^2 as a function
-template <class T>
+template <typename T>
 std::function<t_real(T)> const unconstrained_regularisation(
     const std::function<t_real(T)> &g, const t_real &sig, const T &y,
     const sopt::OperatorFunction<T> &measurement_operator);
 //! returns ||ψ^t x||_1 + ||y - Φ x||_2^2 as a function
-template <class T>
+template <typename T>
 std::function<t_real(T)> const unconstrained_L1_regularisation(
     const t_real &gamma, const t_real &sig, const T &y,
     const sopt::OperatorFunction<T> &measurement_operator,
     const sopt::LinearTransform<T> &wavelet_operator);
-template <class T>
+template <typename T>
 std::function<t_real(T)> const unconstrained_regularisation(
     const std::function<t_real(T)> &g, const t_real &sig, const T &y,
     const sopt::LinearTransform<T> &measurement_operator);
-template <class T>
+template <typename T>
 std::function<t_real(T)> const unconstrained_l1_regularisation(
     const t_real &gamma, const t_real &sig, const T &y,
     const sopt::LinearTransform<T> &measurement_operator,
@@ -33,7 +33,7 @@ std::function<t_real(T)> const unconstrained_l1_regularisation(
 } // namespace sopt::objective_functions
 namespace sopt::objective_functions {
 
-template <class T>
+template <typename T>
 std::function<t_real(T)> const unconstrained_regularisation(
     const std::function<t_real(T)> &g, const t_real &sig, const T &y,
     const sopt::LinearTransform<T> &measurement_operator) {
@@ -41,7 +41,7 @@ std::function<t_real(T)> const unconstrained_regularisation(
     return g(x) + 0.5 * std::pow(sopt::l2_norm(y - measurement_operator * x) / sig, 2);
   };
 }
-template <class T>
+template <typename T>
 std::function<t_real(T)> const unconstrained_l1_regularisation(
     const t_real &gamma, const t_real &sig, const T &y,
     const sopt::LinearTransform<T> &measurement_operator,
@@ -52,14 +52,14 @@ std::function<t_real(T)> const unconstrained_l1_regularisation(
   };
   return unconstrained_regularisation<T>(g, sig, y, measurement_operator);
 }
-template <class T>
+template <typename T>
 std::function<t_real(T)> const unconstrained_regularisation(
     const std::function<t_real(T)> &g, const t_real &sig, const T &y,
     const sopt::OperatorFunction<T> &measurement_operator) {
   const LinearTransform<T> mop = {measurement_operator, measurement_operator};
   return unconstrained_regularisation<T>(g, sig, mop * y, mop);
 }
-template <class T>
+template <typename T>
 std::function<t_real(T)> const unconstrained_l1_regularisation(
     const t_real &gamma, const t_real &sig, const T &y,
     const sopt::OperatorFunction<T> &measurement_operator,

--- a/cpp/sopt/padmm.h
+++ b/cpp/sopt/padmm.h
@@ -15,7 +15,7 @@ namespace sopt::algorithm {
 
 //! \brief Proximal Alternate Direction method of mutltipliers
 //! \details \f$\min_{x, z} f(x) + h(z)\f$ subject to \f$Φx + z = y\f$. \f$y\f$ is a target vector.
-template <class SCALAR>
+template <typename SCALAR>
 class ProximalADMM {
  public:
   //! Scalar type
@@ -56,7 +56,7 @@ class ProximalADMM {
   //! Setups ProximalADMM
   //! \param[in] f_proximal: proximal operator of the \f$f\f$ function.
   //! \param[in] g_proximal: proximal operator of the \f$g\f$ function
-  template <class DERIVED>
+  template <typename DERIVED>
   ProximalADMM(t_Proximal const &f_proximal, t_Proximal const &g_proximal,
                Eigen::MatrixBase<DERIVED> const &target)
       : itermax_(std::numeric_limits<t_uint>::max()),
@@ -119,7 +119,7 @@ class ProximalADMM {
   //! Vector of target measurements
   t_Vector const &target() const { return target_; }
   //! Sets the vector of target measurements
-  template <class DERIVED>
+  template <typename DERIVED>
   ProximalADMM<Scalar> &target(Eigen::MatrixBase<DERIVED> const &target) {
     target_ = target;
     return *this;
@@ -173,7 +173,7 @@ class ProximalADMM {
     return result;
   }
   //! Set Φ and Φ^† using arguments that sopt::linear_transform understands
-  template <class... ARGS>
+  template <typename... ARGS>
   typename std::enable_if<sizeof...(ARGS) >= 1, ProximalADMM &>::type Phi(ARGS &&... args) {
     Phi_ = linear_transform(std::forward<ARGS>(args)...);
     return *this;
@@ -226,7 +226,7 @@ class ProximalADMM {
   t_Vector target_;
 };
 
-template <class SCALAR>
+template <typename SCALAR>
 void ProximalADMM<SCALAR>::iteration_step(t_Vector &out, t_Vector &residual, t_Vector &lambda,
                                           t_Vector &z) const {
   g_proximal(z, gamma(), -lambda - residual);
@@ -236,7 +236,7 @@ void ProximalADMM<SCALAR>::iteration_step(t_Vector &out, t_Vector &residual, t_V
   lambda += lagrange_update_scale() * (residual + z);
 }
 
-template <class SCALAR>
+template <typename SCALAR>
 typename ProximalADMM<SCALAR>::Diagnostic ProximalADMM<SCALAR>::operator()(
     t_Vector &out, t_Vector const &x_guess, t_Vector const &res_guess) const {
   SOPT_HIGH_LOG("Performing Proximal ADMM");

--- a/cpp/sopt/positive_quadrant.h
+++ b/cpp/sopt/positive_quadrant.h
@@ -11,7 +11,7 @@ namespace sopt::algorithm {
 //! \brief Computes according to given algorithm and then projects it to the positive quadrant
 //! \details C implementation of the reweighted algorithms uses this, even-though the solutions are
 //! already constrained to the positive quadrant.
-template <class ALGORITHM>
+template <typename ALGORITHM>
 class PositiveQuadrant {
  public:
   //! Underlying algorithm
@@ -34,7 +34,7 @@ class PositiveQuadrant {
   Algorithm const &algorithm() const { return algorithm_; }
 
   //! Performs algorithm and project results onto positive quadrant
-  template <class... T>
+  template <typename... T>
   Diagnostic operator()(t_Vector &out, T const &... args) const {
     auto const diagnostic = algorithm()(out, std::forward<T const &>(args)...);
     out = positive_quadrant(out);
@@ -42,7 +42,7 @@ class PositiveQuadrant {
   };
 
   //! Performs algorithm and project results onto positive quadrant
-  template <class... T>
+  template <typename... T>
   DiagnosticAndResult operator()(T const &... args) const {
     auto result = algorithm()(std::forward<T const &>(args)...);
     result.x = positive_quadrant(result.x);
@@ -55,7 +55,7 @@ class PositiveQuadrant {
 };
 
 //! Extended algorithm where the solution is projected on the positive quadrant
-template <class ALGORITHM>
+template <typename ALGORITHM>
 PositiveQuadrant<ALGORITHM> positive_quadrant(ALGORITHM const &algo) {
   return {algo};
 }

--- a/cpp/sopt/power_method.h
+++ b/cpp/sopt/power_method.h
@@ -19,7 +19,7 @@
 namespace sopt::algorithm {
 //! \brief Returns the eigenvalue and eigenvector for eigenvalue of the Linear Transform with
 //! largest magnitude
-template <class T>
+template <typename T>
 std::tuple<t_real, T> power_method(const sopt::LinearTransform<T> &op, const t_uint niters,
                                    const t_real relative_difference, const T &initial_vector) {
   /*
@@ -55,7 +55,7 @@ std::tuple<t_real, T> power_method(const sopt::LinearTransform<T> &op, const t_u
   return std::make_tuple(std::sqrt(old_value), estimate_eigen_vector);
 }
 
-template <class T>
+template <typename T>
 std::tuple<t_real, T, std::shared_ptr<sopt::LinearTransform<T>>> normalise_operator(
     const std::shared_ptr<sopt::LinearTransform<T> const> &op, const t_uint &niters,
     const t_real &relative_difference, const T &initial_vector) {
@@ -71,7 +71,7 @@ std::tuple<t_real, T, std::shared_ptr<sopt::LinearTransform<T>>> normalise_opera
           },
           op->adjoint().sizes()));
 }
-template <class T>
+template <typename T>
 std::tuple<t_real, T, sopt::LinearTransform<T>> normalise_operator(
     const sopt::LinearTransform<T> &op, const t_uint &niters, const t_real &relative_difference,
     const T &initial_vector) {
@@ -83,7 +83,7 @@ std::tuple<t_real, T, sopt::LinearTransform<T>> normalise_operator(
 }
 #ifdef SOPT_MPI
 //! Performs an all sum all operation to collectively normalise different serial operators
-template <class T>
+template <typename T>
 std::tuple<t_real, T> all_sum_all_power_method(const sopt::mpi::Communicator &comm,
                                                const sopt::LinearTransform<T> &op,
                                                const t_uint &niters,
@@ -97,7 +97,7 @@ std::tuple<t_real, T> all_sum_all_power_method(const sopt::mpi::Communicator &co
       op.adjoint().sizes());
   return power_method(all_sum_all_op, niters, relative_difference, initial_vector.derived());
 }
-template <class T>
+template <typename T>
 std::tuple<t_real, T, std::shared_ptr<sopt::LinearTransform<T>>> all_sum_all_normalise_operator(
     const sopt::mpi::Communicator &comm, const std::shared_ptr<sopt::LinearTransform<T> const> &op,
     const t_uint &niters, const t_real &relative_difference, const T &initial_vector) {
@@ -120,7 +120,7 @@ std::tuple<t_real, T, std::shared_ptr<sopt::LinearTransform<T>>> all_sum_all_nor
           },
           op->adjoint().sizes()));
 }
-template <class T>
+template <typename T>
 std::tuple<t_real, T, sopt::LinearTransform<T>> all_sum_all_normalise_operator(
     const sopt::mpi::Communicator &comm, const sopt::LinearTransform<T> &op, const t_uint &niters,
     const t_real &relative_difference, const T &initial_vector) {
@@ -133,7 +133,7 @@ std::tuple<t_real, T, sopt::LinearTransform<T>> all_sum_all_normalise_operator(
 }
 #endif
 //! \brief Eigenvalue and eigenvector for eigenvalue with largest magnitude
-template <class SCALAR>
+template <typename SCALAR>
 class PowerMethod {
  public:
   //! Scalar type
@@ -186,7 +186,7 @@ class PowerMethod {
   DiagnosticAndResult AtA(t_LinearTransform const &A, t_Vector const &input) const;
 
   //! \brief Calls the power method for A, with A a matrix
-  template <class DERIVED>
+  template <typename DERIVED>
   DiagnosticAndResult operator()(Eigen::DenseBase<DERIVED> const &A, t_Vector const &input) const;
 
   //! \brief Calls the power method for a given matrix-vector multiplication function
@@ -195,7 +195,7 @@ class PowerMethod {
  protected:
 };
 
-template <class SCALAR>
+template <typename SCALAR>
 typename PowerMethod<SCALAR>::DiagnosticAndResult PowerMethod<SCALAR>::AtA(
     t_LinearTransform const &A, t_Vector const &input) const {
   auto const op = [&A](t_Vector &out, t_Vector const &input) -> void {
@@ -204,8 +204,8 @@ typename PowerMethod<SCALAR>::DiagnosticAndResult PowerMethod<SCALAR>::AtA(
   return operator()(op, input);
 }
 
-template <class SCALAR>
-template <class DERIVED>
+template <typename SCALAR>
+template <typename DERIVED>
 typename PowerMethod<SCALAR>::DiagnosticAndResult PowerMethod<SCALAR>::operator()(
     Eigen::DenseBase<DERIVED> const &A, t_Vector const &input) const {
   Matrix<Scalar> const Ad = A.derived();
@@ -213,7 +213,7 @@ typename PowerMethod<SCALAR>::DiagnosticAndResult PowerMethod<SCALAR>::operator(
   return operator()(op, input);
 }
 
-template <class SCALAR>
+template <typename SCALAR>
 typename PowerMethod<SCALAR>::DiagnosticAndResult PowerMethod<SCALAR>::operator()(
     OperatorFunction<t_Vector> const &op, t_Vector const &input) const {
   SOPT_INFO("Computing the upper bound of a given operator");

--- a/cpp/sopt/primal_dual.h
+++ b/cpp/sopt/primal_dual.h
@@ -20,7 +20,7 @@ namespace sopt::algorithm {
 
 //! \brief Primal Dual Algorithm
 //! \details \f$\min_{x, z} f(x) + h(z)\f$ subject to \f$Φx + z = y\f$. \f$y\f$ is a target vector.
-template <class SCALAR>
+template <typename SCALAR>
 class PrimalDual {
  public:
   //! Scalar type
@@ -65,7 +65,7 @@ class PrimalDual {
   //! Setups PrimalDual
   //! \param[in] f_proximal: proximal operator of the \f$f\f$ function.
   //! \param[in] g_proximal: proximal operator of the \f$g\f$ function
-  template <class DERIVED>
+  template <typename DERIVED>
   PrimalDual(t_Proximal const &f_proximal, t_Proximal const &g_proximal,
              Eigen::MatrixBase<DERIVED> const &target)
       : itermax_(std::numeric_limits<t_uint>::max()),
@@ -163,7 +163,7 @@ class PrimalDual {
   //! Vector of target measurements
   t_Vector const &target() const { return target_; }
   //! Sets the vector of target measurements
-  template <class DERIVED>
+  template <typename DERIVED>
   PrimalDual<Scalar> &target(Eigen::MatrixBase<DERIVED> const &target) {
     target_ = target;
     return *this;
@@ -217,13 +217,13 @@ class PrimalDual {
     return result;
   }
   //! Set Φ and Φ^† using arguments that sopt::linear_transform understands
-  template <class... ARGS>
+  template <typename... ARGS>
   typename std::enable_if<sizeof...(ARGS) >= 1, PrimalDual &>::type Phi(ARGS &&... args) {
     Phi_ = linear_transform(std::forward<ARGS>(args)...);
     return *this;
   }
   //! Set Φ and Φ^† using arguments that sopt::linear_transform understands
-  template <class... ARGS>
+  template <typename... ARGS>
   typename std::enable_if<sizeof...(ARGS) >= 1, PrimalDual &>::type Psi(ARGS &&... args) {
     Psi_ = linear_transform(std::forward<ARGS>(args)...);
     return *this;
@@ -279,7 +279,7 @@ class PrimalDual {
   t_Vector target_;
 };
 
-template <class SCALAR>
+template <typename SCALAR>
 void PrimalDual<SCALAR>::iteration_step(t_Vector &out, t_Vector &out_hold, t_Vector &u,
                                         t_Vector &u_hold, t_Vector &v, t_Vector &v_hold,
                                         t_Vector &residual, t_Vector &q, t_Vector &r,
@@ -321,7 +321,7 @@ void PrimalDual<SCALAR>::iteration_step(t_Vector &out, t_Vector &out_hold, t_Vec
     residual = static_cast<t_Vector>(Phi() * out_hold) * xi() - target();
 }
 
-template <class SCALAR>
+template <typename SCALAR>
 typename PrimalDual<SCALAR>::Diagnostic PrimalDual<SCALAR>::operator()(
     t_Vector &out, t_Vector const &x_guess, t_Vector const &res_guess) const {
   SOPT_HIGH_LOG("Performing Primal Dual");

--- a/cpp/sopt/proximal.h
+++ b/cpp/sopt/proximal.h
@@ -25,7 +25,7 @@ class EuclidianNorm {
     return *this;
   }
 #endif
-  template <class T0>
+  template <typename T0>
   void operator()(Vector<typename T0::Scalar> &out,
                   typename real_type<typename T0::Scalar>::type const &t,
                   Eigen::MatrixBase<T0> const &x) const {
@@ -41,7 +41,7 @@ class EuclidianNorm {
       out.fill(0);
   }
   //! Lazy version
-  template <class T0>
+  template <typename T0>
   ProximalExpression<EuclidianNorm, T0> operator()(typename T0::Scalar const &t,
                                                    Eigen::MatrixBase<T0> const &x) const {
     return {*this, t, x};
@@ -53,20 +53,20 @@ class EuclidianNorm {
 };
 
 //! Proximal of the euclidian norm
-template <class T0>
+template <typename T0>
 auto euclidian_norm(typename real_type<typename T0::Scalar>::type const &t,
                     Eigen::MatrixBase<T0> const &x) -> decltype(EuclidianNorm(), t, x) {
   return EuclidianNorm()(t, x);
 }
 
 //! Proximal of the l1 norm
-template <class T0, class T1>
+template <typename T0, typename T1>
 void l1_norm(Eigen::DenseBase<T0> &out, typename real_type<typename T0::Scalar>::type gamma,
              Eigen::DenseBase<T1> const &x) {
   out = sopt::soft_threshhold<T0>(x, gamma);
 }
 //! Proxmal of the weighted l1 norm
-template <class T0, class T1, class T2>
+template <typename T0, typename T1, typename T2>
 void l1_norm(Eigen::DenseBase<T0> &out, Eigen::DenseBase<T2> const &gamma,
              Eigen::DenseBase<T1> const &x) {
   out = sopt::soft_threshhold<T0, T2>(x, gamma);
@@ -74,26 +74,26 @@ void l1_norm(Eigen::DenseBase<T0> &out, Eigen::DenseBase<T2> const &gamma,
 
 //! \brief Proximal of the l1 norm
 //! \detail This specialization makes it easier to use in algorithms, e.g. within `SDMM::append`.
-template <class S>
+template <typename S>
 void l1_norm(Vector<S> &out, typename real_type<S>::type gamma, Vector<S> const &x) {
   l1_norm<Vector<S>, Vector<S>>(out, gamma, x);
 }
 
 //! Proximal of the l2 norm (note this is different from the l2 ball indicator function)
-template <class T0, class T1>
+template <typename T0, typename T1>
 void l2_norm(Eigen::DenseBase<T0> &out, typename real_type<typename T0::Scalar>::type gamma,
              Eigen::DenseBase<T1> const &x) {
   out = x.derived() * 1. / (1. + gamma);
 }
 
-template <class T0, class T1, class T2>
+template <typename T0, typename T1, typename T2>
 void l2_norm(Eigen::DenseBase<T0> &out, Eigen::DenseBase<T2> const &gamma,
              Eigen::DenseBase<T1> const &x) {
   out = x.derived().array() * 1. / (1. + gamma.derived().array()).array();
 }
 
 //! Proximal of the l1,2 norm that is used in the TV norm
-template <class T0, class T1>
+template <typename T0, typename T1>
 void tv_norm(Eigen::DenseBase<T0> &out, typename real_type<typename T0::Scalar>::type gamma,
              Eigen::DenseBase<T1> const &x) {
   typename Eigen::Index const size = x.size() / 2;
@@ -111,7 +111,7 @@ void tv_norm(Eigen::DenseBase<T0> &out, typename real_type<typename T0::Scalar>:
     }
   }
 }
-template <class T0, class T1, class T2>
+template <typename T0, typename T1, typename T2>
 void tv_norm(Eigen::DenseBase<T0> &out, Eigen::DenseBase<T2> const &gamma,
              Eigen::DenseBase<T1> const &x) {
   typename Eigen::Index const size = x.size() / 2;
@@ -131,7 +131,7 @@ void tv_norm(Eigen::DenseBase<T0> &out, Eigen::DenseBase<T2> const &gamma,
 }
 
 //! Proximal of a function that is always zero, the identity
-template <class T0, class T1>
+template <typename T0, typename T1>
 void id(Eigen::DenseBase<T0> &out, typename real_type<typename T0::Scalar>::type gamma,
         Eigen::DenseBase<T1> const &x) {
   out = x;
@@ -140,20 +140,20 @@ void id(Eigen::DenseBase<T0> &out, typename real_type<typename T0::Scalar>::type
 //! \brief Proximal of l1 norm
 //! \details For more complex version involving linear transforms and weights, see L1TightFrame and
 //! L1 classes. In practice, this is an alias for soft_threshhold.
-template <class T>
+template <typename T>
 auto l1_norm(typename real_type<typename T::Scalar>::type gamma, Eigen::DenseBase<T> const &x)
     -> decltype(sopt::soft_threshhold(x, gamma)) {
   return sopt::soft_threshhold(x, gamma);
 }
 
 //! Proximal for projection on the positive quadrant
-template <class T>
+template <typename T>
 void positive_quadrant(Vector<T> &out, typename real_type<T>::type, Vector<T> const &x) {
   out = sopt::positive_quadrant(x);
 };
 
 //! Proximal for the L2 norm
-template <class T>
+template <typename T>
 class L2Norm {
  public:
   using Real = typename real_type<T>::type;
@@ -165,20 +165,20 @@ class L2Norm {
     proximal::l2_norm(out, gamma, x);
   }
   //! Lazy version
-  template <class T0>
+  template <typename T0>
   EnveloppeExpression<L2Norm, T0> operator()(Real const &, Eigen::MatrixBase<T0> const &x) const {
     return {*this, x};
   }
 
   //! Lazy version
-  template <class T0>
+  template <typename T0>
   EnveloppeExpression<L2Norm, T0> operator()(Eigen::MatrixBase<T0> const &x) const {
     return {*this, x};
   }
 };
 
 //! Proximal for indicator function of L2 ball
-template <class T>
+template <typename T>
 class L2Ball {
  public:
   using Real = typename real_type<T>::type;
@@ -207,13 +207,13 @@ class L2Ball {
       out = x;
   }
   //! Lazy version
-  template <class T0>
+  template <typename T0>
   EnveloppeExpression<L2Ball, T0> operator()(Real const &, Eigen::MatrixBase<T0> const &x) const {
     return {*this, x};
   }
 
   //! Lazy version
-  template <class T0>
+  template <typename T0>
   EnveloppeExpression<L2Ball, T0> operator()(Eigen::MatrixBase<T0> const &x) const {
     return {*this, x};
   }
@@ -242,14 +242,14 @@ class L2Ball {
 #endif
 };
 
-template <class T>
+template <typename T>
 class WeightedL2Ball : public L2Ball<T> {
  public:
   using Real = typename L2Ball<T>::Real;
   using t_Vector = Vector<Real>;
 #ifdef SOPT_MPI
   //! Constructs an L2 ball proximal of size epsilon with given weights
-  template <class T0>
+  template <typename T0>
   WeightedL2Ball(Real epsilon, Eigen::DenseBase<T0> const &w,
                  mpi::Communicator const &comm = mpi::Communicator())
       : L2Ball<T>(epsilon, comm), weights_(w) {}
@@ -263,7 +263,7 @@ class WeightedL2Ball : public L2Ball<T> {
   }
 #else
   //! Constructs an L2 ball proximal of size epsilon with given weights
-  template <class T0>
+  template <typename T0>
   WeightedL2Ball(Real epsilon, Eigen::DenseBase<T0> const &w) : L2Ball<T>(epsilon), weights_(w) {}
   //! Constructs an L2 ball proximal of size epsilon
   WeightedL2Ball(Real epsilon) : WeightedL2Ball(epsilon, t_Vector::Ones(1)) {}
@@ -287,13 +287,13 @@ class WeightedL2Ball : public L2Ball<T> {
       out = x;
   }
   //! Lazy version
-  template <class T0>
+  template <typename T0>
   EnveloppeExpression<WeightedL2Ball, T0> operator()(Real const &,
                                                      Eigen::MatrixBase<T0> const &x) const {
     return {*this, x};
   }
   //! Lazy version
-  template <class T0>
+  template <typename T0>
   EnveloppeExpression<WeightedL2Ball, T0> operator()(Eigen::MatrixBase<T0> const &x) const {
     return {*this, x};
   }
@@ -301,7 +301,7 @@ class WeightedL2Ball : public L2Ball<T> {
   //! Weights associated with each dimension
   t_Vector const &weights() const { return weights_; }
   //! Weights associated with each dimension
-  template <class T0>
+  template <typename T0>
   WeightedL2Ball<T> &weights(Eigen::MatrixBase<T0> const &w) {
     if ((w.array() < 0e0).any()) SOPT_THROW("Weights cannot be negative");
     if (w.stableNorm() < 1e-12) SOPT_THROW("Weights cannot be null");
@@ -321,14 +321,14 @@ class WeightedL2Ball : public L2Ball<T> {
 };
 
 //! Translation over proximal function
-template <class FUNCTION, class VECTOR>
+template <typename FUNCTION, typename VECTOR>
 class Translation {
  public:
   //! Creates proximal of translated function
-  template <class T_VECTOR>
+  template <typename T_VECTOR>
   Translation(FUNCTION const &func, T_VECTOR const &trans) : func(func), trans(trans) {}
   //! Computes proximal of translated function
-  template <class OUTPUT, class T0>
+  template <typename OUTPUT, typename T0>
   typename std::enable_if<std::is_reference<OUTPUT>::value, void>::type operator()(
       OUTPUT out, typename real_type<typename T0::Scalar>::type const &t,
       Eigen::MatrixBase<T0> const &x) const {
@@ -336,7 +336,7 @@ class Translation {
     out -= trans;
   }
   //! Computes proximal of translated function
-  template <class T0>
+  template <typename T0>
   void operator()(Vector<typename T0::Scalar> &out,
                   typename real_type<typename T0::Scalar>::type const &t,
                   Eigen::MatrixBase<T0> const &x) const {
@@ -344,7 +344,7 @@ class Translation {
     out -= trans;
   }
   //! Lazy version
-  template <class T0>
+  template <typename T0>
   ProximalExpression<Translation<FUNCTION, VECTOR> const &, T0> operator()(
       typename T0::Scalar const &t, Eigen::MatrixBase<T0> const &x) const {
     return {*this, t, x};
@@ -358,7 +358,7 @@ class Translation {
 };
 
 //! Translates given proximal by given vector
-template <class FUNCTION, class VECTOR>
+template <typename FUNCTION, typename VECTOR>
 Translation<FUNCTION, VECTOR> translate(FUNCTION const &func, VECTOR const &translation) {
   return Translation<FUNCTION, VECTOR>(func, translation);
 }

--- a/cpp/sopt/proximal_expression.h
+++ b/cpp/sopt/proximal_expression.h
@@ -15,7 +15,7 @@ namespace details {
 //! \details It helps transform the call ``proximal(out, gamma, input)``
 //! to ``out = proximal(gamma, input)`` without incurring copy or allocation overhead if ``out``
 //! already exists.
-template <class FUNCTION, class DERIVED>
+template <typename FUNCTION, typename DERIVED>
 class DelayedProximalFunction
     : public Eigen::ReturnByValue<DelayedProximalFunction<FUNCTION, DERIVED>> {
  public:
@@ -30,7 +30,7 @@ class DelayedProximalFunction
   DelayedProximalFunction(DelayedProximalFunction &&c)
       : func(std::move(c.func)), gamma(c.gamma), x(c.x) {}
 
-  template <class DESTINATION>
+  template <typename DESTINATION>
   void evalTo(DESTINATION &destination) const {
     destination.resizeLike(x);
     func(destination, gamma, x);
@@ -49,7 +49,7 @@ class DelayedProximalFunction
 //! \details It helps transform the call ``proximal(out, input)``
 //! to ``out = proximal(input)`` without incurring copy or allocation overhead if ``out``
 //! already exists.
-template <class FUNCTION, class DERIVED>
+template <typename FUNCTION, typename DERIVED>
 class DelayedProximalEnveloppeFunction
     : public Eigen::ReturnByValue<DelayedProximalEnveloppeFunction<FUNCTION, DERIVED>> {
  public:
@@ -63,7 +63,7 @@ class DelayedProximalEnveloppeFunction
   DelayedProximalEnveloppeFunction(DelayedProximalEnveloppeFunction &&c)
       : func(std::move(c.func)), x(c.x) {}
 
-  template <class DESTINATION>
+  template <typename DESTINATION>
   void evalTo(DESTINATION &destination) const {
     destination.resizeLike(x);
     func(destination, x);
@@ -80,19 +80,19 @@ class DelayedProximalEnveloppeFunction
 }  // namespace details
 
 //! Eigen expression from proximal functions
-template <class FUNC, class T0>
+template <typename FUNC, typename T0>
 using ProximalExpression = details::DelayedProximalFunction<FUNC, Eigen::MatrixBase<T0>>;
 //! Eigen expression from proximal enveloppe functions
-template <class FUNC, class T0>
+template <typename FUNC, typename T0>
 using EnveloppeExpression = details::DelayedProximalEnveloppeFunction<FUNC, Eigen::MatrixBase<T0>>;
 } // namespace sopt::proximal
 
 namespace Eigen::internal {
-template <class FUNCTION, class VECTOR>
+template <typename FUNCTION, typename VECTOR>
 struct traits<sopt::proximal::details::DelayedProximalFunction<FUNCTION, VECTOR>> {
   using ReturnType = typename VECTOR::PlainObject;
 };
-template <class FUNCTION, class VECTOR>
+template <typename FUNCTION, typename VECTOR>
 struct traits<sopt::proximal::details::DelayedProximalEnveloppeFunction<FUNCTION, VECTOR>> {
   using ReturnType = typename VECTOR::PlainObject;
 };

--- a/cpp/sopt/real_type.h
+++ b/cpp/sopt/real_type.h
@@ -9,7 +9,7 @@ namespace sopt {
 namespace details {
 
 // Checks wether a type has contains a type "value_type"
-template <class T, class Enable = void>
+template <typename T, typename Enable = void>
 struct HasValueType {
   using Have = char[1];
   using HaveNot = char[2];
@@ -18,7 +18,7 @@ struct HasValueType {
     struct value_type {};
   };
   struct Derived : T, Fallback {};
-  template <class U>
+  template <typename U>
   static Have &test(typename U::value_type *);
   template <typename U>
   static HaveNot &test(U *);
@@ -27,38 +27,38 @@ struct HasValueType {
   static constexpr bool value = sizeof(test<Derived>(nullptr)) == sizeof(HaveNot);
 };
 // Specialization for fundamental type that cannot be derived from
-template <class T>
+template <typename T>
 struct HasValueType<T, typename std::enable_if<std::is_fundamental<T>::value>::type>
     : std::false_type {};
 //! Detects whether a class contains a value_type type
-template <class T, bool = details::HasValueType<T>::value>
+template <typename T, bool = details::HasValueType<T>::value>
 class has_value_type;
-template <class T>
+template <typename T>
 class has_value_type<T, true> : public std::true_type {};
-template <class T>
+template <typename T>
 class has_value_type<T, false> : public std::false_type {};
 //! Computes inner-most element type
-template <class T, bool = has_value_type<T>::value>
+template <typename T, bool = has_value_type<T>::value>
 class underlying_value_type;
-template <class T>
+template <typename T>
 class underlying_value_type<T, false> {
  public:
   using type = T;
 };
-template <class T>
+template <typename T>
 class underlying_value_type<T, true> {
  public:
   using type = typename underlying_value_type<typename T::value_type>::type;
 };
 }  // namespace details
 //! Gets to the underlying real type
-template <class T>
+template <typename T>
 using real_type = details::underlying_value_type<T>;
 //! True if underlying type is complex
-template <class T, class SP = void>
+template <typename T, typename SP = void>
 struct is_complex : public std::false_type {};
 //! True if underlying type is complex
-template <class T>
+template <typename T>
 struct is_complex<std::complex<T>, void> : public std::true_type {};
 }  // namespace sopt
 #endif

--- a/cpp/sopt/relative_variation.h
+++ b/cpp/sopt/relative_variation.h
@@ -9,7 +9,7 @@
 
 namespace sopt {
 
-template <class TYPE>
+template <typename TYPE>
 class RelativeVariation {
  public:
   //! Underlying scalar type
@@ -24,12 +24,12 @@ class RelativeVariation {
       : tolerance_(c.tolerance_), previous_(c.previous_){};
 
   //! True if object has changed by less than tolerance
-  template <class T>
+  template <typename T>
   bool operator()(Eigen::MatrixBase<T> const &input) {
     return operator()(input.array());
   }
   //! True if object has changed by less than tolerance
-  template <class T>
+  template <typename T>
   bool operator()(Eigen::ArrayBase<T> const &input);
   //! Allowed variation
   Real tolerance() const { return tolerance_; }
@@ -51,7 +51,7 @@ class RelativeVariation {
   std::string name_;
 };
 
-template <class TYPE>
+template <typename TYPE>
 class ScalarRelativeVariation {
  public:
   //! Underlying scalar type
@@ -107,8 +107,8 @@ class ScalarRelativeVariation {
   bool is_first_;
 };
 
-template <class SCALAR>
-template <class T>
+template <typename SCALAR>
+template <typename T>
 bool RelativeVariation<SCALAR>::operator()(Eigen::ArrayBase<T> const &input) {
   if (previous_.size() != input.size()) {
     previous_ = input;
@@ -120,7 +120,7 @@ bool RelativeVariation<SCALAR>::operator()(Eigen::ArrayBase<T> const &input) {
   return norm < tolerance() * tolerance();
 }
 
-template <class SCALAR>
+template <typename SCALAR>
 bool ScalarRelativeVariation<SCALAR>::operator()(Scalar const &current) {
   if (is_first_) {
     previous_ = current;

--- a/cpp/sopt/reweighted.h
+++ b/cpp/sopt/reweighted.h
@@ -10,11 +10,11 @@
 
 namespace sopt::algorithm {
 
-template <class ALGORITHM>
+template <typename ALGORITHM>
 class Reweighted;
 
 //! Factory function to create an l0-approximation by reweighting an l1 norm
-template <class ALGORITHM>
+template <typename ALGORITHM>
 Reweighted<ALGORITHM> reweighted(ALGORITHM const &algo,
                                  typename Reweighted<ALGORITHM>::t_SetWeights const &set_weights,
                                  typename Reweighted<ALGORITHM>::t_Reweightee const &reweightee);
@@ -30,7 +30,7 @@ Reweighted<ALGORITHM> reweighted(ALGORITHM const &algo,
 //! - the inner algorithm, e.g. ImagingProximalADMM
 //! - a function returning Ψ^Tx given x
 //! - a function to modify the inner algorithm with new weights
-template <class ALGORITHM>
+template <typename ALGORITHM>
 class Reweighted {
  public:
   //! Inner-loop algorithm
@@ -136,7 +136,7 @@ class Reweighted {
 
   //! \brief Performs reweighting
   //! \details This overload will compute an initial result without initial weights set to one.
-  template <class INPUT>
+  template <typename INPUT>
   typename std::enable_if<not(std::is_same<INPUT, typename Algorithm::DiagnosticAndResult>::value or
                               std::is_same<INPUT, ReweightedResult>::value),
                           ReweightedResult>::type
@@ -174,8 +174,8 @@ class Reweighted {
   t_DeltaUpdate update_delta_;
 };
 
-template <class ALGORITHM>
-template <class INPUT>
+template <typename ALGORITHM>
+template <typename INPUT>
 typename std::enable_if<
     not(std::is_same<INPUT, typename ALGORITHM::DiagnosticAndResult>::value or
         std::is_same<INPUT, typename Reweighted<ALGORITHM>::ReweightedResult>::value),
@@ -186,14 +186,14 @@ Reweighted<ALGORITHM>::operator()(INPUT const &input) const {
   return operator()(algo(input));
 }
 
-template <class ALGORITHM>
+template <typename ALGORITHM>
 typename Reweighted<ALGORITHM>::ReweightedResult Reweighted<ALGORITHM>::operator()() const {
   Algorithm algo = algorithm();
   set_weights(algo, WeightVector::Ones(1));
   return operator()(algo());
 }
 
-template <class ALGORITHM>
+template <typename ALGORITHM>
 typename Reweighted<ALGORITHM>::ReweightedResult Reweighted<ALGORITHM>::operator()(
     typename Algorithm::DiagnosticAndResult const &warm) const {
   ReweightedResult result;
@@ -202,7 +202,7 @@ typename Reweighted<ALGORITHM>::ReweightedResult Reweighted<ALGORITHM>::operator
   return operator()(result);
 }
 
-template <class ALGORITHM>
+template <typename ALGORITHM>
 typename Reweighted<ALGORITHM>::ReweightedResult Reweighted<ALGORITHM>::operator()(
     ReweightedResult const &warm) const {
   SOPT_HIGH_LOG("Starting reweighted scheme");
@@ -234,22 +234,22 @@ typename Reweighted<ALGORITHM>::ReweightedResult Reweighted<ALGORITHM>::operator
 }
 
 //! Factory function to create an l0-approximation by reweighting an l1 norm
-template <class ALGORITHM>
+template <typename ALGORITHM>
 Reweighted<ALGORITHM> reweighted(ALGORITHM const &algo,
                                  typename Reweighted<ALGORITHM>::t_SetWeights const &set_weights,
                                  typename Reweighted<ALGORITHM>::t_Reweightee const &reweightee) {
   return {algo, set_weights, reweightee};
 }
 
-template <class SCALAR>
+template <typename SCALAR>
 class ImagingProximalADMM;
-template <class ALGORITHM>
+template <typename ALGORITHM>
 class PositiveQuadrant;
-template <class T>
+template <typename T>
 Eigen::CwiseUnaryOp<const details::ProjectPositiveQuadrant<typename T::Scalar>, const T>
 positive_quadrant(Eigen::DenseBase<T> const &input);
 
-template <class SCALAR>
+template <typename SCALAR>
 Reweighted<PositiveQuadrant<ImagingProximalADMM<SCALAR>>> reweighted(
     ImagingProximalADMM<SCALAR> const &algo) {
   auto const posq = positive_quadrant(algo);
@@ -265,15 +265,15 @@ Reweighted<PositiveQuadrant<ImagingProximalADMM<SCALAR>>> reweighted(
   return {posq, set_weights, reweightee};
 }
 
-template <class SCALAR>
+template <typename SCALAR>
 class PrimalDual;
-template <class ALGORITHM>
+template <typename ALGORITHM>
 class PositiveQuadrant;
-template <class T>
+template <typename T>
 Eigen::CwiseUnaryOp<const details::ProjectPositiveQuadrant<typename T::Scalar>, const T>
 positive_quadrant(Eigen::DenseBase<T> const &input);
 
-template <class SCALAR>
+template <typename SCALAR>
 Reweighted<PositiveQuadrant<PrimalDual<SCALAR>>> reweighted(PrimalDual<SCALAR> const &algo) {
   auto const posq = positive_quadrant(algo);
   using Algorithm = typename std::remove_const<decltype(posq)>::type;

--- a/cpp/sopt/sampling.h
+++ b/cpp/sopt/sampling.h
@@ -19,25 +19,25 @@ class Sampling {
   //! Constructs from a vector
   Sampling(t_uint size, std::vector<t_uint> const &indices) : indices_(indices), size(size) {}
   //! Constructs from the size and the number of samples to pick
-  template <class RNG>
+  template <typename RNG>
   Sampling(t_uint size, t_uint samples, RNG &&rng);
   //! Constructs from the size and the number of samples to pick
   Sampling(t_uint size, t_uint samples)
       : Sampling(size, samples, std::mt19937_64(std::random_device()())) {}
 
   // Performs sampling
-  template <class T0, class T1>
+  template <typename T0, typename T1>
   void operator()(Eigen::DenseBase<T0> &out, Eigen::DenseBase<T1> const &x) const;
   // Performs sampling
-  template <class T0, class T1>
+  template <typename T0, typename T1>
   void operator()(Eigen::DenseBase<T0> &&out, Eigen::DenseBase<T1> const &x) const {
     operator()(out, x);
   }
   // Performs adjunct of sampling
-  template <class T0, class T1>
+  template <typename T0, typename T1>
   void adjoint(Eigen::DenseBase<T0> &out, Eigen::DenseBase<T1> const &x) const;
   // Performs adjunct sampling
-  template <class T0, class T1>
+  template <typename T0, typename T1>
   void adjoint(Eigen::DenseBase<T0> &&out, Eigen::DenseBase<T1> const &x) const {
     adjoint(out, x);
   }
@@ -57,7 +57,7 @@ class Sampling {
   t_uint size;
 };
 
-template <class T0, class T1>
+template <typename T0, typename T1>
 void Sampling::operator()(Eigen::DenseBase<T0> &out, Eigen::DenseBase<T1> const &x) const {
   out.resize(indices_.size());
   for (decltype(indices_.size()) i(0); i < indices_.size(); ++i) {
@@ -66,7 +66,7 @@ void Sampling::operator()(Eigen::DenseBase<T0> &out, Eigen::DenseBase<T1> const 
   }
 }
 
-template <class T0, class T1>
+template <typename T0, typename T1>
 void Sampling::adjoint(Eigen::DenseBase<T0> &out, Eigen::DenseBase<T1> const &x) const {
   assert(static_cast<t_uint>(x.size()) == indices_.size());
   out.resize(out.size());
@@ -78,7 +78,7 @@ void Sampling::adjoint(Eigen::DenseBase<T0> &out, Eigen::DenseBase<T1> const &x)
 }
 
 //! Returns linear transform version of this object.
-template <class T>
+template <typename T>
 LinearTransform<Vector<T>> linear_transform(Sampling const &sampling) {
   return linear_transform<Vector<T>>(
       [sampling](Vector<T> &out, Vector<T> const &x) { sampling(out, x); },
@@ -87,7 +87,7 @@ LinearTransform<Vector<T>> linear_transform(Sampling const &sampling) {
       {{0, 1, static_cast<t_int>(sampling.cols())}});
 }
 
-template <class RNG>
+template <typename RNG>
 Sampling::Sampling(t_uint size, t_uint samples, RNG &&rng) : indices_(size), size(size) {
   std::iota(indices_.begin(), indices_.end(), 0);
   std::shuffle(indices_.begin(), indices_.end(), rng);

--- a/cpp/sopt/sdmm.h
+++ b/cpp/sopt/sdmm.h
@@ -19,7 +19,7 @@ namespace sopt::algorithm {
 
 //! \brief Simultaneous-direction method of the multipliers
 //! \details The algorithm is detailed in (doi) 10.1093/mnras/stu202.
-template <class SCALAR>
+template <typename SCALAR>
 class SDMM {
  public:
   //! Values indicating how the algorithm ran
@@ -86,29 +86,29 @@ class SDMM {
     return *this;
   }
   //! \brief Appends a proximal and linear transform
-  template <class PROXIMAL, class T>
+  template <typename PROXIMAL, typename T>
   SDMM<SCALAR> &append(PROXIMAL proximal, T args) {
     proximals().emplace_back(proximal);
     transforms().emplace_back(linear_transform(args));
     return *this;
   }
   //! \brief Appends a proximal with identity as the linear transform
-  template <class PROXIMAL>
+  template <typename PROXIMAL>
   SDMM<SCALAR> &append(PROXIMAL proximal) {
     return append(proximal, linear_transform_identity<Scalar>());
   }
   //! \brief Appends a proximal with the linear transform as pair of functions
-  template <class PROXIMAL, class L, class LADJOINT>
+  template <typename PROXIMAL, typename L, typename LADJOINT>
   SDMM<SCALAR> &append(PROXIMAL proximal, L l, LADJOINT ladjoint) {
     return append(proximal, linear_transform<t_Vector>(l, ladjoint));
   }
   //! \brief Appends a proximal with the linear transform as pair of functions
-  template <class PROXIMAL, class L, class LADJOINT>
+  template <typename PROXIMAL, typename L, typename LADJOINT>
   SDMM<SCALAR> &append(PROXIMAL proximal, L l, LADJOINT ladjoint, std::array<t_int, 3> sizes) {
     return append(proximal, linear_transform<t_Vector>(l, ladjoint, sizes));
   }
   //! \brief Appends a proximal with the linear transform as pair of functions
-  template <class PROXIMAL, class L, class LADJOINT>
+  template <typename PROXIMAL, typename L, typename LADJOINT>
   SDMM<SCALAR> &append(PROXIMAL proximal, L l, std::array<t_int, 3> dsizes, LADJOINT ladjoint,
                        std::array<t_int, 3> isizes) {
     return append(proximal, linear_transform<t_Vector>(l, dsizes, ladjoint, isizes));
@@ -149,7 +149,7 @@ class SDMM {
   //! Proximal associated with a given objective function
   t_Proximal &proximals(t_uint i) { return proximals_[i]; }
   //! Lazy call to specific proximal function
-  template <class T0>
+  template <typename T0>
   proximal::ProximalExpression<t_Proximal const &, T0> proximals(
       t_uint i, Eigen::MatrixBase<T0> const &x) const {
     return {proximals()[i], gamma(), x};
@@ -162,7 +162,7 @@ class SDMM {
   // match the getter with the same name.
   //! \brief Forwards to internal conjugage gradient object
   //! \details Removes the need for ugly extra brackets.
-  template <class T0, class... T>
+  template <typename T0, typename... T>
   auto conjugate_gradient(T0 &&t0, T &&... args) const
       -> decltype(this->conjugate_gradient()(std::forward<T0>(t0), std::forward<T>(args)...)) {
     return conjugate_gradient()(std::forward<T0>(t0), std::forward<T>(args)...);
@@ -192,7 +192,7 @@ class SDMM {
   virtual void sanity_check(t_Vector const &input) const;
 };
 
-template <class SCALAR>
+template <typename SCALAR>
 typename SDMM<SCALAR>::Diagnostic SDMM<SCALAR>::operator()(t_Vector &out,
                                                            t_Vector const &input) const {
   sanity_check(input);
@@ -229,7 +229,7 @@ typename SDMM<SCALAR>::Diagnostic SDMM<SCALAR>::operator()(t_Vector &out,
   return {niters, convergence, cg_diagnostic};
 }
 
-template <class SCALAR>
+template <typename SCALAR>
 ConjugateGradient::Diagnostic SDMM<SCALAR>::solve_for_xn(t_Vector &out, t_Vectors const &y,
                                                          t_Vectors const &z) const {
   assert(z.size() == transforms().size());
@@ -262,7 +262,7 @@ ConjugateGradient::Diagnostic SDMM<SCALAR>::solve_for_xn(t_Vector &out, t_Vector
   return diagnostic;
 }
 
-template <class SCALAR>
+template <typename SCALAR>
 void SDMM<SCALAR>::update_directions(t_Vectors &y, t_Vectors &z, t_Vector const &x) const {
   SOPT_TRACE("Updating directions");
   for (t_uint i(0); i < transforms().size(); ++i) {
@@ -272,7 +272,7 @@ void SDMM<SCALAR>::update_directions(t_Vectors &y, t_Vectors &z, t_Vector const 
   }
 }
 
-template <class SCALAR>
+template <typename SCALAR>
 void SDMM<SCALAR>::initialization(t_Vectors &y, t_Vectors &z, t_Vector const &x) const {
   SOPT_TRACE("Initializing SDMM");
   for (t_uint i(0); i < transforms().size(); i++) {
@@ -284,7 +284,7 @@ void SDMM<SCALAR>::initialization(t_Vectors &y, t_Vectors &z, t_Vector const &x)
   }
 }
 
-template <class SCALAR>
+template <typename SCALAR>
 void SDMM<SCALAR>::sanity_check(t_Vector const &x) const {
   bool doexit = false;
   if (proximals().size() != transforms().size()) {

--- a/cpp/sopt/tf_g_proximal.h
+++ b/cpp/sopt/tf_g_proximal.h
@@ -25,7 +25,7 @@ namespace sopt::algorithm {
 // Implementation of g_proximal with a TensorFlow model. Owns private
 // object model_ and implements the
 // interface defined by the GProximal class
-template <class SCALAR>
+template <typename SCALAR>
 class TFGProximal : public GProximal<SCALAR> {
 
 public:

--- a/cpp/sopt/tv_primal_dual.h
+++ b/cpp/sopt/tv_primal_dual.h
@@ -15,7 +15,7 @@
 #include "sopt/types.h"
 
 namespace sopt::algorithm {
-template <class SCALAR>
+template <typename SCALAR>
 class TVPrimalDual {
   //! Underlying algorithm
   using PD = PrimalDual<SCALAR>;
@@ -26,7 +26,7 @@ class TVPrimalDual {
   using Real = typename PD::Real;
   using t_Vector = typename PD::t_Vector;
   using t_LinearTransform = typename PD::t_LinearTransform;
-  template <class T>
+  template <typename T>
   using t_Proximal = std::function<void(t_Vector &, const T &, const t_Vector &)>;
   using t_IsConverged = typename PD::t_IsConverged;
   using t_Constraint = typename PD::t_Constraint;
@@ -47,7 +47,7 @@ class TVPrimalDual {
   //! Setups imaging wrapper for PD
   //! \param[in] f_proximal: proximal operator of the \f$f\f$ function.
   //! \param[in] g_proximal: proximal operator of the \f$g\f$ function
-  template <class DERIVED>
+  template <typename DERIVED>
   TVPrimalDual(Eigen::MatrixBase<DERIVED> const &target)
       : tv_proximal_([](t_Vector &out, const Real &gamma, const t_Vector &x) {
           proximal::tv_norm<t_Vector, t_Vector>(out, gamma, x);
@@ -160,7 +160,7 @@ class TVPrimalDual {
   //! Vector of target measurements
   t_Vector const &target() const { return target_; }
   //! Sets the vector of target measurements
-  template <class DERIVED>
+  template <typename DERIVED>
   TVPrimalDual<Scalar> &target(Eigen::MatrixBase<DERIVED> const &target) {
     target_ = target;
     return *this;
@@ -213,7 +213,7 @@ class TVPrimalDual {
   }
 
   //! Set Φ and Φ^† using arguments that sopt::linear_transform understands
-  template <class... ARGS>
+  template <typename... ARGS>
   typename std::enable_if<sizeof...(ARGS) >= 1, TVPrimalDual &>::type Phi(ARGS &&... args) {
     Phi_ = linear_transform(std::forward<ARGS>(args)...);
     return *this;
@@ -224,7 +224,7 @@ class TVPrimalDual {
   proximal::WeightedL2Ball<Scalar> &l2ball_proximal() { return l2ball_proximal_; }
 
   //! Analysis operator Ψ
-  template <class... ARGS>
+  template <typename... ARGS>
   typename std::enable_if<sizeof...(ARGS) >= 1, TVPrimalDual &>::type Psi(ARGS &&... args) {
     Psi_ = linear_transform(std::forward<ARGS>(args)...);
     return *this;
@@ -298,7 +298,7 @@ class TVPrimalDual {
   };
 };
 
-template <class SCALAR>
+template <typename SCALAR>
 typename TVPrimalDual<SCALAR>::Diagnostic TVPrimalDual<SCALAR>::operator()(
     t_Vector &out, t_Vector const &guess, t_Vector const &res) const {
   SOPT_HIGH_LOG("Performing Primal Dual with TV and L2 operators");
@@ -361,7 +361,7 @@ typename TVPrimalDual<SCALAR>::Diagnostic TVPrimalDual<SCALAR>::operator()(
   return result;
 }
 
-template <class SCALAR>
+template <typename SCALAR>
 bool TVPrimalDual<SCALAR>::residual_convergence(t_Vector const &x, t_Vector const &residual) const {
   if (static_cast<bool>(residual_convergence())) return residual_convergence()(x, residual);
   if (residual_tolerance() <= 0e0) return true;
@@ -370,7 +370,7 @@ bool TVPrimalDual<SCALAR>::residual_convergence(t_Vector const &x, t_Vector cons
   return residual_norm < residual_tolerance();
 };
 
-template <class SCALAR>
+template <typename SCALAR>
 bool TVPrimalDual<SCALAR>::objective_convergence(ScalarRelativeVariation<Scalar> &scalvar,
                                                  t_Vector const &x,
                                                  t_Vector const &residual) const {
@@ -381,7 +381,7 @@ bool TVPrimalDual<SCALAR>::objective_convergence(ScalarRelativeVariation<Scalar>
   return scalvar(current);
 };
 
-template <class SCALAR>
+template <typename SCALAR>
 bool TVPrimalDual<SCALAR>::is_converged(ScalarRelativeVariation<Scalar> &scalvar, t_Vector const &x,
                                         t_Vector const &residual) const {
   auto const user = static_cast<bool>(is_converged()) == false or is_converged()(x, residual);

--- a/cpp/sopt/types.h
+++ b/cpp/sopt/types.h
@@ -20,35 +20,35 @@ using t_complex = std::complex<t_real>;
 
 //! \brief A vector of a given type
 //! \details Operates as mathematical vector.
-template <class T = t_real>
+template <typename T = t_real>
 using Vector = Eigen::Matrix<T, Eigen::Dynamic, 1>;
 
 //! \brief A matrix of a given type
 //! \details Operates as mathematical matrix.
-template <class T = t_real>
+template <typename T = t_real>
 using Matrix = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
 
 //! \brief A 1-dimensional list of elements of given type
 //! \details Operates coefficient-wise, not matrix-vector-wise
-template <class T = t_real>
+template <typename T = t_real>
 using Array = Eigen::Array<T, Eigen::Dynamic, 1>;
 
 //! \brief A 2-dimensional list of elements of given type
 //! \details Operates coefficient-wise, not matrix-vector-wise
-template <class T = t_real>
+template <typename T = t_real>
 using Image = Eigen::Array<T, Eigen::Dynamic, Eigen::Dynamic>;
 
 //! Typical function out = A*x
-template <class VECTOR = Vector<>>
+template <typename VECTOR = Vector<>>
 using OperatorFunction = std::function<void(VECTOR &, VECTOR const &)>;
 
 //! Typical function signature for calls to proximal
-template <class SCALAR = t_real>
+template <typename SCALAR = t_real>
 using ProximalFunction =
     std::function<void(Vector<SCALAR> &, typename real_type<SCALAR>::type, Vector<SCALAR> const &)>;
 
 //! Typical function signature for convergence
-template <class SCALAR = t_real>
+template <typename SCALAR = t_real>
 using ConvergenceFunction = std::function<bool(Vector<SCALAR> const &)>;
 }  // namespace sopt
 #endif

--- a/cpp/sopt/wavelets.h
+++ b/cpp/sopt/wavelets.h
@@ -15,7 +15,7 @@ namespace sopt {
 namespace details {
 namespace {
 //! Thin linear-transform wrapper around some operator accepting direct and indirect
-template <class T, class OP>
+template <typename T, typename OP>
 LinearTransform<Vector<T>> linear_transform(OP const &op) {
   return LinearTransform<Vector<T>>(
       [op](Vector<T> &out, Vector<T> const &x) { op.indirect(x.array(), out.array()); },
@@ -28,7 +28,7 @@ LinearTransform<Vector<T>> linear_transform(OP const &op) {
 //! \param[in] rows: Number of rows in the image
 //! \param[in] cols: Number of columns in the image
 //! \param[in] factor: Allows for SARA transforms, i.e. more than one wavelet basis
-template <class T, class OP>
+template <typename T, typename OP>
 LinearTransform<Vector<T>> linear_transform(OP const &op, t_uint rows, t_uint cols,
                                             t_uint factor = 1) {
   return LinearTransform<Vector<T>>(
@@ -54,41 +54,41 @@ LinearTransform<Vector<T>> linear_transform(OP const &op, t_uint rows, t_uint co
 
 namespace utilities {
 //! return wavelet basis coefficients from a dictionary
-template <class T>
+template <typename T>
 Vector<T> &get_wavelet_basis_coefficients(Vector<T> &coeffs, const t_uint basis_index,
                                           const t_uint size);
 //! return wavelet basis coefficients for a given level and below (1d case)
-template <class T>
+template <typename T>
 Vector<T> &get_wavelet_levels_1d(Vector<T> &coeffs, const t_uint level, const t_uint size);
 //! return wavelet basis coefficients for a given level and below (2d case)
-template <class T>
+template <typename T>
 Vector<T> &get_wavelet_levels(Vector<T> &coeffs, const t_uint level, const t_uint rows,
                               const t_uint cols);
 //! return wavelet basis coefficients low pass (rows) and high pass (cols) for a given level
-template <class T>
+template <typename T>
 Vector<T> &get_wavelet_low_high_pass(Vector<T> &coeffs, const t_uint level, const t_uint rows,
                                      const t_uint cols);
 //! return wavelet basis coefficients high pass (rows) and high pass (cols) for a given level
-template <class T>
+template <typename T>
 Vector<T> &get_wavelet_high_high_pass(Vector<T> &coeffs, const t_uint level, const t_uint rows,
                                       const t_uint cols);
 //! return wavelet basis coefficients high pass (rows) and high pass (cols) for a given level
-template <class T>
+template <typename T>
 Vector<T> &get_wavelet_high_low_pass(Vector<T> &coeffs, const t_uint level, const t_uint rows,
                                      const t_uint cols);
 //! return wavelet basis coefficients high pass (rows) and high pass (cols) for a given level
-template <class T>
+template <typename T>
 Vector<T> &get_wavelet_low_low_pass(Vector<T> &coeffs, const t_uint level, const t_uint rows,
                                     const t_uint cols);
 //! return 1d high pass filter for a given level of a wavelet
-template <class T>
+template <typename T>
 Vector<T> &get_wavelet_high_pass_1d(Vector<T> &coeffs, const t_uint level, const t_uint size);
 // macro to add version to work with a wavelet dictionary
 #define SOPT_WAVELET_MACRO(NAME)                                                                 \
-  template <class T>                                                                             \
+  template <typename T>                                                                             \
   Vector<T> &NAME(Vector<T> &coeffs, const t_uint basis_index, const t_uint level,               \
                   const t_uint rows, const t_uint cols);                                         \
-  template <class T>                                                                             \
+  template <typename T>                                                                             \
   Vector<T> &NAME(Vector<T> &coeffs, const t_uint basis_index, const t_uint level,               \
                   const t_uint rows, const t_uint cols) {                                        \
     return NAME(get_wavelet_basis_coefficients(coeffs, basis_index, coeffs.size()), level, rows, \
@@ -101,23 +101,23 @@ SOPT_WAVELET_MACRO(get_wavelet_high_low_pass)
 SOPT_WAVELET_MACRO(get_wavelet_low_low_pass)
 #undef SOPT_WAVELET_MACRO
 // implimentations
-template <class T>
+template <typename T>
 Vector<T> &get_wavelet_basis_coefficients(Vector<T> &coeffs, const t_uint basis_index,
                                           const t_uint size) {
   assert(coeffs.size() > basis_index * size);
   return coeffs.segment(basis_index * size, size);
 }
-template <class T>
+template <typename T>
 Vector<T> &get_wavelet_levels_1d(Vector<T> &coeffs, const t_uint level, const t_uint size) {
   auto const N = static_cast<t_uint>(coeffs.size()) >> level;  // bitshift to divide by 2^level
   return coeffs.head(N);
 }
-template <class T>
+template <typename T>
 Vector<T> &get_wavelet_high_pass_1d(Vector<T> &coeffs, const t_uint level, const t_uint size) {
   auto const N = static_cast<t_uint>(coeffs.size()) >> level;  // bitshift to divide by 2^level
   return get_wavelet_levels(coeffs, level, size).tail(N / 2);
 }
-template <class T>
+template <typename T>
 Vector<T> &get_wavelet_levels(Vector<T> &coeffs, const t_uint level, const t_uint rows,
                               const t_uint cols) {
   const Matrix<T> signal = Matrix<T>::Map(coeffs.data(), rows, cols);
@@ -125,7 +125,7 @@ Vector<T> &get_wavelet_levels(Vector<T> &coeffs, const t_uint level, const t_uin
   auto const Ny = static_cast<t_uint>(signal.cols()) >> level;
   return Vector<T>::Map(signal.topLeftCorner(Nx, Ny).data(), Nx * Ny);
 }
-template <class T>
+template <typename T>
 Vector<T> &get_wavelet_low_high_pass(Vector<T> &coeffs, const t_uint level, const t_uint rows,
                                      const t_uint cols) {
   auto const Nx = rows >> level;  // bitshift to divide by 2^level
@@ -135,7 +135,7 @@ Vector<T> &get_wavelet_low_high_pass(Vector<T> &coeffs, const t_uint level, cons
   return Vector<T>::Map(signal.topRightCorner(signal.rows() / 2, signal.cols() / 2).data(),
                         signal.size() / 4);
 }
-template <class T>
+template <typename T>
 Vector<T> &get_wavelet_high_high_pass(Vector<T> &coeffs, const t_uint level, const t_uint rows,
                                       const t_uint cols) {
   auto const Nx = rows >> level;  // bitshift to divide by 2^level
@@ -145,7 +145,7 @@ Vector<T> &get_wavelet_high_high_pass(Vector<T> &coeffs, const t_uint level, con
   return Vector<T>::Map(signal.bottomRightCorner(signal.rows() / 2, signal.cols() / 2).data(),
                         signal.size() / 4);
 }
-template <class T>
+template <typename T>
 Vector<T> &get_wavelet_high_low_pass(Vector<T> &coeffs, const t_uint level, const t_uint rows,
                                      const t_uint cols) {
   auto const Nx = rows >> level;  // bitshift to divide by 2^level
@@ -155,7 +155,7 @@ Vector<T> &get_wavelet_high_low_pass(Vector<T> &coeffs, const t_uint level, cons
   return Vector<T>::Map(signal.bottomLeftCorner(signal.rows() / 2, signal.cols() / 2).data(),
                         signal.size() / 4);
 }
-template <class T>
+template <typename T>
 Vector<T> &get_wavelet_low_low_pass(Vector<T> &coeffs, const t_uint level, const t_uint rows,
                                     const t_uint cols) {
   auto const Nx = rows >> level;  // bitshift to divide by 2^level
@@ -171,7 +171,7 @@ Vector<T> &get_wavelet_low_low_pass(Vector<T> &coeffs, const t_uint level, const
 //! \brief Thin linear-transform wrapper around 1d wavelets
 //! \warning Because of the way Purify defines things, Ψ^T is
 //! actually the transform from signal to coefficients.
-template <class T>
+template <typename T>
 LinearTransform<Vector<T>> linear_transform(wavelets::Wavelet const &wavelet) {
   return details::linear_transform<T, wavelets::Wavelet>(wavelet);
 }
@@ -179,7 +179,7 @@ LinearTransform<Vector<T>> linear_transform(wavelets::Wavelet const &wavelet) {
 //! \brief Thin linear-transform wrapper around 1d sara operator
 //! \note Because of the way Purify defines things, Ψ^T is
 //! actually the transform from signal to coefficients.
-template <class T>
+template <typename T>
 LinearTransform<Vector<T>> linear_transform(wavelets::SARA const &sara) {
   return details::linear_transform<T, wavelets::SARA>(sara);
 }
@@ -187,7 +187,7 @@ LinearTransform<Vector<T>> linear_transform(wavelets::SARA const &sara) {
 //! \brief Thin linear-transform wrapper around 2d wavelets
 //! \note Because of the way Purify defines things, Ψ^T is
 //! actually the transform from signal to coefficients.
-template <class T>
+template <typename T>
 LinearTransform<Vector<T>> linear_transform(wavelets::Wavelet const &wavelet, t_uint rows,
                                             t_uint cols = 1) {
   return details::linear_transform<T, wavelets::Wavelet>(wavelet, rows, cols);
@@ -198,7 +198,7 @@ LinearTransform<Vector<T>> linear_transform(wavelets::Wavelet const &wavelet, t_
 //! \param[in] cols: Number of columns in the image
 //! \note Because of the way Purify defines things, Ψ^T is actually the transform from signal to
 //! coefficients.
-template <class T>
+template <typename T>
 LinearTransform<Vector<T>> linear_transform(wavelets::SARA const &sara, t_uint rows,
                                             t_uint cols = 1) {
   return details::linear_transform<T, wavelets::SARA>(sara, rows, cols, sara.size());
@@ -212,7 +212,7 @@ LinearTransform<Vector<T>> linear_transform(wavelets::SARA const &sara, t_uint r
 //! \note There is an issue with using the adjoint wavelet transform of the SARA basis.
 //! When there are more nodes than wavelets, this function will return an empty Vector<T>()
 //! on the extra nodes. This can cause some functions to break, like .maxCoeff().
-template <class T>
+template <typename T>
 LinearTransform<Vector<T>> linear_transform(wavelets::SARA const &sara, t_uint rows, t_uint cols,
                                             sopt::mpi::Communicator const &comm) {
   auto const factor = sara.size();

--- a/cpp/sopt/wavelets/direct.h
+++ b/cpp/sopt/wavelets/direct.h
@@ -15,7 +15,7 @@ namespace {
 //! \param[out] coeffs_: output of the function (despite the const)
 //! \param[in] signal: input signal for which to compute wavelet transform
 //! \param[in] wavelet: contains wavelet coefficients
-template <class T0, class T1>
+template <typename T0, typename T1>
 typename std::enable_if<T1::IsVectorAtCompileTime, void>::type direct_transform_impl(
     Eigen::ArrayBase<T0> const &coeffs_, Eigen::ArrayBase<T1> const &signal,
     WaveletData const &wavelet) {
@@ -32,7 +32,7 @@ typename std::enable_if<T1::IsVectorAtCompileTime, void>::type direct_transform_
 //! \param[out] coeffs_: output of the function (despite the const)
 //! \param[inout] signal: input signal for which to compute wavelet transform. Input is modified.
 //! \param[in] wavelet: contains wavelet coefficients
-template <class T0, class T1>
+template <typename T0, typename T1>
 typename std::enable_if<not T1::IsVectorAtCompileTime, void>::type direct_transform_impl(
     Eigen::ArrayBase<T0> const &coeffs_, Eigen::ArrayBase<T1> const &signal_,
     WaveletData const &wavelet) {
@@ -57,7 +57,7 @@ typename std::enable_if<not T1::IsVectorAtCompileTime, void>::type direct_transf
 //! \param[in] wavelet: contains wavelet coefficients
 //! \note The size  of the coefficients should a multiple of $2^l$ where $l$ is the number of
 //! levels.
-template <class T0, class T1>
+template <typename T0, typename T1>
 typename std::enable_if<T1::IsVectorAtCompileTime, void>::type direct_transform(
     Eigen::ArrayBase<T0> &coeffs, Eigen::ArrayBase<T1> const &signal, t_uint levels,
     WaveletData const &wavelet) {
@@ -77,7 +77,7 @@ typename std::enable_if<T1::IsVectorAtCompileTime, void>::type direct_transform(
 //! \param[in] wavelet: contains wavelet coefficients
 //! \note The size  of the coefficients should a multiple of $2^l$ where $l$ is the number of
 //! levels.
-template <class T0, class T1>
+template <typename T0, typename T1>
 typename std::enable_if<not T1::IsVectorAtCompileTime, void>::type direct_transform(
     Eigen::ArrayBase<T0> const &coeffs_, Eigen::ArrayBase<T1> const &signal, t_uint levels,
     WaveletData const &wavelet) {
@@ -103,7 +103,7 @@ typename std::enable_if<not T1::IsVectorAtCompileTime, void>::type direct_transf
 //! \brief Direct 1d and 2d transform
 //! \note The size  of the coefficients should a multiple of $2^l$ where $l$ is the number of
 //! levels.
-template <class T0>
+template <typename T0>
 auto direct_transform(Eigen::ArrayBase<T0> const &signal, t_uint levels, WaveletData const &wavelet)
     -> decltype(copy(signal)) {
   auto result = copy(signal);

--- a/cpp/sopt/wavelets/indirect.h
+++ b/cpp/sopt/wavelets/indirect.h
@@ -15,7 +15,7 @@ namespace {
 //! \param[in] coeffs_: input coefficients
 //! \param[out] signal: output with the reconstituted signal
 //! \param[in] wavelet: contains wavelet coefficients
-template <class T0, class T1>
+template <typename T0, typename T1>
 typename std::enable_if<T1::IsVectorAtCompileTime, void>::type indirect_transform_impl(
     Eigen::ArrayBase<T0> const &coeffs, Eigen::ArrayBase<T1> const &signal_,
     WaveletData const &wavelet) {
@@ -31,7 +31,7 @@ typename std::enable_if<T1::IsVectorAtCompileTime, void>::type indirect_transfor
 //! \param[in] coeffs_: input coefficients
 //! \param[out] signal: output with the reconstituted signal
 //! \param[in] wavelet: contains wavelet coefficients
-template <class T0, class T1>
+template <typename T0, typename T1>
 typename std::enable_if<not T1::IsVectorAtCompileTime, void>::type indirect_transform_impl(
     Eigen::ArrayBase<T0> const &coeffs_, Eigen::ArrayBase<T1> const &signal_,
     WaveletData const &wavelet) {
@@ -54,7 +54,7 @@ typename std::enable_if<not T1::IsVectorAtCompileTime, void>::type indirect_tran
 //! \param[in] wavelet: contains wavelet coefficients
 //! \note The size  of the coefficients should a multiple of $2^l$ where $l$ is the number of
 //! levels.
-template <class T0, class T1>
+template <typename T0, typename T1>
 typename std::enable_if<T1::IsVectorAtCompileTime, void>::type indirect_transform(
     Eigen::ArrayBase<T0> const &coeffs, Eigen::ArrayBase<T1> &signal, t_uint levels,
     WaveletData const &wavelet) {
@@ -78,7 +78,7 @@ typename std::enable_if<T1::IsVectorAtCompileTime, void>::type indirect_transfor
 //! \param[in] wavelet: contains wavelet coefficients
 //! \note The size  of the signal and coefficients should a multiple of $2^l$ where $l$ is the
 //! number of levels.
-template <class T0, class T1>
+template <typename T0, typename T1>
 typename std::enable_if<not T1::IsVectorAtCompileTime, void>::type indirect_transform(
     Eigen::ArrayBase<T0> const &coeffs_, Eigen::ArrayBase<T1> const &signal_, t_uint levels,
     WaveletData const &wavelet) {
@@ -108,7 +108,7 @@ typename std::enable_if<not T1::IsVectorAtCompileTime, void>::type indirect_tran
 //! \returns the reconstituted signal
 //! \note The size  of the coefficients should a multiple of $2^l$ where $l$ is the number of
 //! levels.
-template <class T0>
+template <typename T0>
 auto indirect_transform(Eigen::ArrayBase<T0> const &coeffs, t_uint levels,
                         WaveletData const &wavelet) -> decltype(copy(coeffs)) {
   auto result = copy(coeffs);

--- a/cpp/sopt/wavelets/innards.impl.h
+++ b/cpp/sopt/wavelets/innards.impl.h
@@ -11,7 +11,7 @@ namespace {
 //! \brief Returns evaluated expression or copy of input
 //! \details Gets C++ to figure out what the exact type is. Eigen tries and avoids copies. But
 //! sometimes we actually want a copy, to make sure the arguments of a function are not modified
-template <class T0>
+template <typename T0>
 auto copy(Eigen::ArrayBase<T0> const &a) ->
     typename std::remove_const<typename std::remove_reference<decltype(a.eval())>::type>::type {
   return a.eval();
@@ -22,7 +22,7 @@ auto copy(Eigen::ArrayBase<T0> const &a) ->
 //! - `a` can be seen as a periodic vector: `a[i] == a[i % a.size()]`
 //! - `a'` is the segment `a` = a[offset:offset+b.size()]`
 //! - the result is the scalar product of `a'` by `b`.
-template <class T0, class T2>
+template <typename T0, typename T2>
 typename T0::Scalar periodic_scalar_product(Eigen::ArrayBase<T0> const &a,
                                             Eigen::ArrayBase<T2> const &b,
                                             typename T0::Index offset) {
@@ -43,7 +43,7 @@ typename T0::Scalar periodic_scalar_product(Eigen::ArrayBase<T0> const &a,
 
 //! \brief Convolves the signal by the filter
 //! \details The signal is seen as a periodic vector during convolution
-template <class T0, class T1, class T2>
+template <typename T0, typename T1, typename T2>
 void convolve(Eigen::ArrayBase<T0> &result, Eigen::ArrayBase<T1> const &signal,
               Eigen::ArrayBase<T2> const &filter) {
   assert(result.size() == signal.size());
@@ -51,7 +51,7 @@ void convolve(Eigen::ArrayBase<T0> &result, Eigen::ArrayBase<T1> const &signal,
     result(i) = periodic_scalar_product(signal, filter, i);
 }
 //! \brief Convolve variation for vector blocks
-template <class T0, class T1, class T2>
+template <typename T0, typename T1, typename T2>
 void convolve(Eigen::VectorBlock<T0> &&result, Eigen::ArrayBase<T1> const &signal,
               Eigen::ArrayBase<T2> const &filter) {
   return convolve(result, signal, filter);
@@ -59,7 +59,7 @@ void convolve(Eigen::VectorBlock<T0> &&result, Eigen::ArrayBase<T1> const &signa
 
 //! \brief Convolves and down-samples the signal by the filter
 //! \details Just like convolve, but does every other point.
-template <class T0, class T1, class T2>
+template <typename T0, typename T1, typename T2>
 void down_convolve(Eigen::ArrayBase<T0> &result, Eigen::ArrayBase<T1> const &signal,
                    Eigen::ArrayBase<T2> const &filter) {
   assert(result.size() * 2 <= signal.size());
@@ -78,14 +78,14 @@ void down_convolve(Eigen::ArrayBase<T0> &result, Eigen::ArrayBase<T1> const &sig
   }
 }
 //! \brief Dowsampling + convolve variation for vector blocks
-template <class T0, class T1, class T2>
+template <typename T0, typename T1, typename T2>
 void down_convolve(Eigen::VectorBlock<T0> &&result, Eigen::ArrayBase<T1> const &signal,
                    Eigen::ArrayBase<T2> const &filter) {
   down_convolve(result, signal, filter);
 }
 
 //! Convolve and sims low and high pass of a signal
-template <class T0, class T1, class T2, class T3, class T4>
+template <typename T0, typename T1, typename T2, typename T3, typename T4>
 void convolve_sum(Eigen::ArrayBase<T0> &result, Eigen::ArrayBase<T1> const &low_pass_signal,
                   Eigen::ArrayBase<T2> const &low_pass,
                   Eigen::ArrayBase<T3> const &high_pass_signal,
@@ -109,7 +109,7 @@ void convolve_sum(Eigen::ArrayBase<T0> &result, Eigen::ArrayBase<T1> const &low_
 //! some unnecessary operations (multiplying and summing zeros) and removes the
 //! need for temporary copies.  Testing shows the operations are equivalent. But
 //! I certainly cannot show how on paper.
-template <class T0, class T1, class T2, class T3, class T4, class T5>
+template <typename T0, typename T1, typename T2, typename T3, typename T4, typename T5>
 void up_convolve_sum(Eigen::ArrayBase<T0> &result, Eigen::ArrayBase<T1> const &coeffs,
                      Eigen::ArrayBase<T2> const &low_even, Eigen::ArrayBase<T3> const &low_odd,
                      Eigen::ArrayBase<T4> const &high_even, Eigen::ArrayBase<T5> const &high_odd) {

--- a/cpp/sopt/wavelets/sara.h
+++ b/cpp/sopt/wavelets/sara.h
@@ -30,7 +30,7 @@ class SARA : public std::vector<Wavelet> {
   SARA(std::initializer_list<std::tuple<std::string, t_uint>> const &init)
       : SARA(init.begin(), init.end()) {}
   //! Construct from any iterator over a (std:string, t_uint) tuple
-  template <class ITERATOR,
+  template <typename ITERATOR,
             class T = typename std::enable_if<
                 std::is_convertible<decltype(std::get<0>(*std::declval<ITERATOR>())),
                                     std::string>::value and
@@ -51,7 +51,7 @@ class SARA : public std::vector<Wavelet> {
   //! \return wavelets coefficients arranged by columns: if the input is n by m, then the output
   //! is n by m * d, with d the number of wavelets.
   //! \details Supports 1 and 2 dimensional tranforms for real and complex data.
-  template <class T0>
+  template <typename T0>
   typename T0::PlainObject direct(Eigen::ArrayBase<T0> const &signal) const;
   //! \brief Direct transform
   //! \param[inout] coefficients: Output wavelet coefficients. Must be of the type as the input.
@@ -61,7 +61,7 @@ class SARA : public std::vector<Wavelet> {
   //! multiple of $2^l$ where $l$ is the maximum number of levels. Can be a matrix (2d-transform)
   //! or a column vector (1-d transform).
   //! \details Supports 1 and 2 dimensional tranforms for real and complex data.
-  template <class T0, class T1>
+  template <typename T0, typename T1>
   void direct(Eigen::ArrayBase<T1> &coefficients, Eigen::ArrayBase<T0> const &signal) const;
   //! \brief Direct transform
   //! \param[inout] coefficients: Output wavelet coefficients. Must be of the type as the input.
@@ -73,7 +73,7 @@ class SARA : public std::vector<Wavelet> {
   //! \details Supports 1 and 2 dimensional tranforms for real and complex data. This version
   //! allows non-constant Eigen expressions to be passe on without the ugly `const_cast` of the
   //! cannonical approach.
-  template <class T0, class T1>
+  template <typename T0, typename T1>
   void direct(Eigen::ArrayBase<T1> &&coefficients, Eigen::ArrayBase<T0> const &signal) const {
     direct(coefficients, signal);
   }
@@ -82,14 +82,14 @@ class SARA : public std::vector<Wavelet> {
   //! where $l$ is the number of levels. Can be a matrix (2d-transform) or a column vector (1-d
   //! transform).
   //! \details Supports 1 and 2 dimensional tranforms for real and complex data.
-  template <class T0>
+  template <typename T0>
   typename T0::PlainObject indirect(Eigen::ArrayBase<T0> const &coeffs) const;
   //! \brief Indirect transform
   //! \param[in] coefficients: Input wavelet coefficients. Its size must be a multiple of $2^l$
   //! where $l$ is the number of levels. Can be a matrix (2d-transform) or a column vector (1-d
   //! \param[inout] signal: Reconstructed signal. Must be of the same size and type as the input.
   //! \details Supports 1 and 2 dimensional tranforms for real and complex data.
-  template <class T0, class T1>
+  template <typename T0, typename T1>
   void indirect(Eigen::ArrayBase<T1> const &coefficients, Eigen::ArrayBase<T0> &signal) const;
   //! \brief Indirect transform
   //! \param[in] coefficients: Input wavelet coefficients. Its size must be a multiple of $2^l$
@@ -98,7 +98,7 @@ class SARA : public std::vector<Wavelet> {
   //! \details Supports 1 and 2 dimensional tranforms for real and complex data.  This version
   //! allows non-constant Eigen expressions to be passe on without the ugly `const_cast` of the
   //! cannonical approach.
-  template <class T0, class T1>
+  template <typename T0, typename T1>
   void indirect(Eigen::ArrayBase<T1> const &coeffs, Eigen::ArrayBase<T0> &&signal) const {
     indirect(coeffs, signal);
   }
@@ -122,7 +122,7 @@ class SARA : public std::vector<Wavelet> {
   else if ((INPUT).cols() != 1 and (INPUT).cols() % (1u << max_levels()))             \
     throw std::length_error("Inconsistent number of rows and wavelet levels");
 
-template <class T0, class T1>
+template <typename T0, typename T1>
 void SARA::direct(Eigen::ArrayBase<T1> &coeffs, Eigen::ArrayBase<T0> const &signal) const {
   SOPT_WAVELET_ERROR_MACRO(signal);
   if (coeffs.rows() != signal.rows() or coeffs.cols() != signal.cols() * static_cast<t_int>(size()))
@@ -145,7 +145,7 @@ void SARA::direct(Eigen::ArrayBase<T1> &coeffs, Eigen::ArrayBase<T0> const &sign
   coeffs /= std::sqrt(size());
 }
 
-template <class T0, class T1>
+template <typename T0, typename T1>
 void SARA::indirect(Eigen::ArrayBase<T1> const &coeffs, Eigen::ArrayBase<T0> &signal) const {
   if (size() == 0) throw std::runtime_error("Empty wavelets: adjoint operation undefined");
   if (signal.cols() == 1) {
@@ -177,7 +177,7 @@ void SARA::indirect(Eigen::ArrayBase<T1> const &coeffs, Eigen::ArrayBase<T0> &si
 
 #undef SOPT_WAVELET_ERROR_MACRO
 
-template <class T0>
+template <typename T0>
 typename T0::PlainObject SARA::indirect(Eigen::ArrayBase<T0> const &coeffs) const {
   using t_Output = decltype(this->front().indirect(coeffs));
   t_Output signal = t_Output::Zero(coeffs.rows(), coeffs.cols() / size());
@@ -185,7 +185,7 @@ typename T0::PlainObject SARA::indirect(Eigen::ArrayBase<T0> const &coeffs) cons
   return signal;
 }
 
-template <class T0>
+template <typename T0>
 typename T0::PlainObject SARA::direct(Eigen::ArrayBase<T0> const &signal) const {
   using t_Output = decltype(this->front().direct(signal));
   t_Output result = t_Output::Zero(signal.rows(), signal.cols() * size());
@@ -197,7 +197,7 @@ typename T0::PlainObject SARA::direct(Eigen::ArrayBase<T0> const &signal) const 
 //! \brief Creates a sara transform distributed across processors
 //! \details This is a convenience function for creating a distributed linear transform above. It
 //! does not perform any mpi operation itself.
-template <class T>
+template <typename T>
 T distribute_sara(T const &sara, t_uint size, t_uint rank) {
   auto const start = [](t_uint size, t_uint ncomms, t_uint rank) {
     return std::min(size, rank * (size / ncomms) + std::min(rank, size % ncomms));
@@ -206,7 +206,7 @@ T distribute_sara(T const &sara, t_uint size, t_uint rank) {
   auto const endw = start(sara.size(), size, rank + 1);
   return T(sara.begin() + startw, sara.begin() + endw);
 }
-template <class T>
+template <typename T>
 T distribute_sara(T const &all_wavelets, mpi::Communicator const &comm) {
   return distribute_sara<T>(all_wavelets, comm.size(), comm.rank());
 }

--- a/cpp/sopt/wavelets/wavelets.h
+++ b/cpp/sopt/wavelets/wavelets.h
@@ -48,7 +48,7 @@ class Wavelet : public WaveletData {
   //! column vector (1-d transform).
   //! \return wavelet coefficients
   //! \details Supports 1 and 2 dimensional tranforms for real and complex data.
-  template <class T0>
+  template <typename T0>
   auto direct(Eigen::ArrayBase<T0> const &signal) const
       -> decltype(direct_transform(signal, 1, *this)) {
     SOPT_WAVELET_MACRO_MULTIPLE(signal);
@@ -62,7 +62,7 @@ class Wavelet : public WaveletData {
   //! column vector
   //! (1-d transform).
   //! \details Supports 1 and 2 dimensional tranforms for real and complex data.
-  template <class T0, class T1>
+  template <typename T0, typename T1>
   auto direct(Eigen::ArrayBase<T1> &coefficients, Eigen::ArrayBase<T0> const &signal) const
       -> decltype(direct_transform(coefficients, signal, 1, *this)) {
     SOPT_WAVELET_MACRO_MULTIPLE(signal);
@@ -79,7 +79,7 @@ class Wavelet : public WaveletData {
   //! \details Supports 1 and 2 dimensional tranforms for real and complex data. This version
   //! allows non-constant Eigen expressions to be passe on without the ugly `const_cast` of the
   //! cannonical approach.
-  template <class T0, class T1>
+  template <typename T0, typename T1>
   auto direct(Eigen::ArrayBase<T1> &&coefficients, Eigen::ArrayBase<T0> const &signal) const
       -> decltype(direct_transform(coefficients, signal, 1, *this)) {
     SOPT_WAVELET_MACRO_MULTIPLE(signal);
@@ -91,7 +91,7 @@ class Wavelet : public WaveletData {
   //! where $l$ is the number of levels. Can be a matrix (2d-transform) or a column vector (1-d
   //! transform).
   //! \details Supports 1 and 2 dimensional tranforms for real and complex data.
-  template <class T0>
+  template <typename T0>
   auto indirect(Eigen::ArrayBase<T0> const &coefficients) const
       -> decltype(indirect_transform(coefficients, 1, *this)) {
     SOPT_WAVELET_MACRO_MULTIPLE(coefficients);
@@ -102,7 +102,7 @@ class Wavelet : public WaveletData {
   //! where $l$ is the number of levels. Can be a matrix (2d-transform) or a column vector (1-d
   //! \param[inout] signal: Reconstructed signal. Must be of the same size and type as the input.
   //! \details Supports 1 and 2 dimensional tranforms for real and complex data.
-  template <class T0, class T1>
+  template <typename T0, typename T1>
   auto indirect(Eigen::ArrayBase<T1> const &coefficients, Eigen::ArrayBase<T0> &signal) const
       -> decltype(indirect_transform(coefficients, signal, 1, *this)) {
     SOPT_WAVELET_MACRO_MULTIPLE(coefficients);
@@ -116,7 +116,7 @@ class Wavelet : public WaveletData {
   //! \details Supports 1 and 2 dimensional tranforms for real and complex data.  This version
   //! allows non-constant Eigen expressions to be passe on without the ugly `const_cast` of the
   //! cannonical approach.
-  template <class T0, class T1>
+  template <typename T0, typename T1>
   auto indirect(Eigen::ArrayBase<T1> const &coeffs, Eigen::ArrayBase<T0> &&signal) const
       -> decltype(indirect_transform(coeffs, signal, 1, *this)) {
     SOPT_WAVELET_MACRO_MULTIPLE(coeffs);

--- a/cpp/sopt/wrapper.h
+++ b/cpp/sopt/wrapper.h
@@ -12,7 +12,7 @@
 
 namespace sopt::details {
 //! Expression referencing the result of a function call
-template <class FUNCTION, class DERIVED>
+template <typename FUNCTION, typename DERIVED>
 class AppliedFunction : public Eigen::ReturnByValue<AppliedFunction<FUNCTION, DERIVED>> {
  public:
   using PlainObject = typename DERIVED::PlainObject;
@@ -24,7 +24,7 @@ class AppliedFunction : public Eigen::ReturnByValue<AppliedFunction<FUNCTION, DE
   AppliedFunction(AppliedFunction const &c) : func(c.func), x(c.x), rows_(c.rows_) {}
   AppliedFunction(AppliedFunction &&c) : func(std::move(c.func)), x(c.x), rows_(c.rows_) {}
 
-  template <class DESTINATION>
+  template <typename DESTINATION>
   void evalTo(DESTINATION &destination) const {
     func(destination, x);
   }
@@ -42,7 +42,7 @@ class AppliedFunction : public Eigen::ReturnByValue<AppliedFunction<FUNCTION, DE
 //! \details This makes writing the application of a function more beautiful on the eye.
 //! A function call `func(output, input)` can be made to look like `output = func(input)` or `output
 //! = func * input`.
-template <class VECTOR>
+template <typename VECTOR>
 class WrapFunction {
  public:
   //! Type of function wrapped here
@@ -70,28 +70,28 @@ class WrapFunction {
   }
 
   //! Function application form
-  template <class T0>
+  template <typename T0>
   AppliedFunction<t_Function const &, Eigen::ArrayBase<T0>> operator()(
       Eigen::ArrayBase<T0> const &x) const {
     return AppliedFunction<t_Function const &, Eigen::ArrayBase<T0>>(func, x, rows(x));
   }
 
   //! Multiplication application form
-  template <class T0>
+  template <typename T0>
   AppliedFunction<t_Function const &, Eigen::ArrayBase<T0>> operator*(
       Eigen::ArrayBase<T0> const &x) const {
     return AppliedFunction<t_Function const &, Eigen::ArrayBase<T0>>(func, x, rows(x));
   }
 
   //! Function application form
-  template <class T0>
+  template <typename T0>
   AppliedFunction<t_Function const &, Eigen::MatrixBase<T0>> operator()(
       Eigen::MatrixBase<T0> const &x) const {
     return AppliedFunction<t_Function const &, Eigen::MatrixBase<T0>>(func, x, rows(x));
   }
 
   //! Multiplication application form
-  template <class T0>
+  template <typename T0>
   AppliedFunction<t_Function const &, Eigen::MatrixBase<T0>> operator*(
       Eigen::MatrixBase<T0> const &x) const {
     return AppliedFunction<t_Function const &, Eigen::MatrixBase<T0>>(func, x, rows(x));
@@ -106,7 +106,7 @@ class WrapFunction {
   std::array<t_int, 3> const &sizes() const { return sizes_; }
 
   //! Output vector size for a input with `xsize` elements
-  template <class T>
+  template <typename T>
   typename std::enable_if<std::is_integral<T>::value, T>::type rows(T xsize) const {
     auto const result = (static_cast<t_int>(xsize) * sizes_[0]) / sizes_[1] + sizes_[2];
     assert(result >= 0);
@@ -114,7 +114,7 @@ class WrapFunction {
   }
 
  protected:
-  template <class T>
+  template <typename T>
   t_uint rows(Eigen::DenseBase<T> const &x) const {
     return rows(x.size());
   }
@@ -127,7 +127,7 @@ class WrapFunction {
 };
 
 //! Helper function to wrap functor into expression-able object
-template <class VECTOR>
+template <typename VECTOR>
 WrapFunction<VECTOR> wrap(OperatorFunction<VECTOR> const &func,
                           std::array<t_int, 3> sizes = {{1, 1, 0}}) {
   return WrapFunction<VECTOR>(func, sizes);
@@ -135,7 +135,7 @@ WrapFunction<VECTOR> wrap(OperatorFunction<VECTOR> const &func,
 } // namespace sopt::details
 
 namespace Eigen::internal {
-template <class FUNCTION, class VECTOR>
+template <typename FUNCTION, typename VECTOR>
 struct traits<sopt::details::AppliedFunction<FUNCTION, VECTOR>> {
   using ReturnType = typename VECTOR::PlainObject;
 };

--- a/cpp/tests/forward_backward.cc
+++ b/cpp/tests/forward_backward.cc
@@ -59,9 +59,9 @@ TEST_CASE("Forward Backward with ||x - x0||_2^2 function", "[fb]") {
   CHECK(result.niters < itermax);
 }
 
-template <class T> struct is_imaging_proximal_ref
+template <typename T> struct is_imaging_proximal_ref
     : public std::is_same<sopt::algorithm::ImagingForwardBackward<double> &, T> {};
-template <class T> struct is_l1_g_proximal_ref
+template <typename T> struct is_l1_g_proximal_ref
     : public std::is_same<sopt::algorithm::L1GProximal<double> &, T> {};
 
 TEST_CASE("Check type returned on setting variables") {

--- a/cpp/tests/padmm.cc
+++ b/cpp/tests/padmm.cc
@@ -45,7 +45,7 @@ TEST_CASE("Proximal ADMM with ||x - x0||_2 functions", "[padmm][integration]") {
   CHECK((result.x - target0 - alpha * segment).stableNorm() < 1e-8);
 }
 
-template <class T>
+template <typename T>
 struct is_imaging_proximal_ref
     : public std::is_same<sopt::algorithm::ImagingProximalADMM<double> &, T> {};
 TEST_CASE("Check type returned on setting variables") {

--- a/cpp/tests/primal_dual.cc
+++ b/cpp/tests/primal_dual.cc
@@ -81,7 +81,7 @@ TEST_CASE("Primal Dual with 0.5 * ||x - x0||_2^2 function", "[primaldual]") {
   CHECK(result.niters < 200);
 }
 
-template <class T>
+template <typename T>
 struct is_primal_dual_ref : public std::is_same<sopt::algorithm::ImagingPrimalDual<double> &, T> {};
 TEST_CASE("Check type returned on setting variables") {
   // Yeah, could be static asserts

--- a/cpp/tests/proximal.cc
+++ b/cpp/tests/proximal.cc
@@ -7,7 +7,7 @@
 #include "sopt/proximal.h"
 #include "sopt/types.h"
 
-template <class T>
+template <typename T>
 sopt::Matrix<T> concatenated_permutations(sopt::t_uint i, sopt::t_uint j) {
   extern std::unique_ptr<std::mt19937_64> mersenne;
   std::vector<size_t> cols(j);

--- a/cpp/tests/wavelets.cc
+++ b/cpp/tests/wavelets.cc
@@ -19,7 +19,7 @@ t_iVector odd(t_iVector const &x) {
   for (t_iVector::Index i(1); i < x.size(); i += 2) result(i / 2) = x(i);
   return result;
 };
-template <class T>
+template <typename T>
 Eigen::Array<typename T::Scalar, T::RowsAtCompileTime, T::ColsAtCompileTime> upsample(
     Eigen::ArrayBase<T> const &input) {
   using Matrix = Eigen::Array<typename T::Scalar, T::RowsAtCompileTime, T::ColsAtCompileTime>;
@@ -45,7 +45,7 @@ t_iVector random_ivector(sopt::t_int size, sopt::t_int min, sopt::t_int max) {
 };
 
 // Checks round trip operation
-template <class T0>
+template <typename T0>
 void check_round_trip(Eigen::ArrayBase<T0> const &input_, sopt::t_uint db,
                       sopt::t_uint nlevels = 1) {
   auto const input = input_.eval();

--- a/cpp/tools_for_tests/cdata.h
+++ b/cpp/tools_for_tests/cdata.h
@@ -7,7 +7,7 @@
 
 namespace sopt {
 // Wraps calls to sampling and wavelets to C style
-template <class T>
+template <typename T>
 struct CData {
   using t_Vector = Eigen::Matrix<T, Eigen::Dynamic, 1>;
   typename t_Vector::Index nin, nout;
@@ -15,7 +15,7 @@ struct CData {
   t_uint direct_calls, adjoint_calls;
 };
 
-template <class T>
+template <typename T>
 void direct_transform(void *out, void *in, void **data) {
   CData<T> const &cdata = *(CData<T> *)data;
   using t_Vector = Eigen::Matrix<T, Eigen::Dynamic, 1>;
@@ -23,7 +23,7 @@ void direct_transform(void *out, void *in, void **data) {
   ++(((CData<T> *)data)->direct_calls);
   t_Vector::Map((T *)out, cdata.nout) = eval;
 }
-template <class T>
+template <typename T>
 void adjoint_transform(void *out, void *in, void **data) {
   CData<T> const &cdata = *(CData<T> *)data;
   using t_Vector = Eigen::Matrix<T, Eigen::Dynamic, 1>;

--- a/cpp/tools_for_tests/inpainting.h
+++ b/cpp/tools_for_tests/inpainting.h
@@ -8,12 +8,12 @@
 
 namespace sopt {
 
-template <class T>
+template <typename T>
 Vector<T> target(sopt::LinearTransform<Vector<T>> const &sampling, sopt::Image<T> const &image) {
   return sampling * Vector<T>::Map(image.data(), image.size());
 }
 
-template <class T>
+template <typename T>
 typename real_type<T>::type sigma(sopt::LinearTransform<Vector<T>> const &sampling,
                                   sopt::Image<T> const &image) {
   auto const snr = 30.0;
@@ -21,7 +21,7 @@ typename real_type<T>::type sigma(sopt::LinearTransform<Vector<T>> const &sampli
   return y0.stableNorm() / std::sqrt(y0.size()) * std::pow(10.0, -(snr / 20.0));
 }
 
-template <class T, class RANDOM>
+template <typename T, typename RANDOM>
 Vector<T> dirty(sopt::LinearTransform<Vector<T>> const &sampling, sopt::Image<T> const &image,
                 RANDOM &mersenne) {
   // values near the mean are the most likely
@@ -34,7 +34,7 @@ Vector<T> dirty(sopt::LinearTransform<Vector<T>> const &sampling, sopt::Image<T>
   return y;
 }
 
-template <class T>
+template <typename T>
 typename real_type<T>::type epsilon(sopt::LinearTransform<Vector<T>> const &sampling,
                                     sopt::Image<T> const &image) {
   auto const y0 = target(sampling, image);


### PR DESCRIPTION
Although there is no technical difference between `class` and `typename` for type template parameters, we may argue that `typename`  better conveys its semantic meaning.

To many people's chagrin, `class` is a much overloaded keyword. When using the keyword `class`, are we referring to a custom `class` or simply a placeholder for a templated type? Clearly, `typename` has better semantics in my opinion.