### PR TITLE
feat(build-system): disable in-source builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,10 @@
 cmake_minimum_required(VERSION 3.13.4) # CMake 3.13.4 is the currently default in Debian 10 repositories
+
+# Do not allow in-source builds.
+if(PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
+	message(FATAL_ERROR "In-source builds are not allowed!\nCreate a \"build\" dir and remove:\n- ${CMAKE_SOURCE_DIR}/CMakeCache.txt\n- ${CMAKE_SOURCE_DIR}/CMakeFiles")
+endif()
+
 project(Sopt
         DESCRIPTION "Sparse OPTimisation using state-of-the-art convex optimisation algorithms."
         HOMEPAGE_URL "http://astro-informatics.github.io/sopt/"


### PR DESCRIPTION
This tiny PR will be one of several towards incrementally improving the build system in many subtle (and sometimes in breaking ways). This is one of the gentler PRs that is almost invisible.
_____________________________________

CMake doesn't provide a built-in way of disabling in-source builds. However, there is a community-wide accepted solution for preventing in-source builds, which this PR incorporates.