### PR TITLE
cpp/sopt/config.in.h: Add the missing #include <cstdint>

### DIFF
--- a/cpp/sopt/config.in.h
+++ b/cpp/sopt/config.in.h
@@ -22,6 +22,7 @@
 #cmakedefine SOPT_ULONG_ARCH
 
 
+#include <cstdint>
 #include <string>
 #include <tuple>
 


### PR DESCRIPTION
This fixes a build failure with gcc 13:

```
In file included from /build/1st/sopt-3.0.1+dfsg/cpp/sopt/../sopt/mpi/session.h:4,
                 from /build/1st/sopt-3.0.1+dfsg/cpp/sopt/mpi/session.cc:1:
/build/1st/sopt-3.0.1+dfsg/obj-x86_64-linux-gnu/include/sopt/config.h:32:19: error: 'uint8_t' was not declared in this scope
   32 | inline std::tuple<uint8_t, uint8_t, uint8_t> version_tuple() {
      |                   ^~~~~~~
/build/1st/sopt-3.0.1+dfsg/obj-x86_64-linux-gnu/include/sopt/config.h:27:1: note: 'uint8_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
   26 | #include <tuple>
  +++ |+#include <cstdint>
   27 | 
```