### PR TITLE
Fix normalisation of initial guess

### DIFF
--- a/cpp/sopt/primal_dual.h
+++ b/cpp/sopt/primal_dual.h
@@ -246,7 +246,7 @@ class PrimalDual {
   static std::tuple<t_Vector, t_Vector> initial_guess(t_Vector const &target,
                                                       t_LinearTransform const &phi, Real nu) {
     std::tuple<t_Vector, t_Vector> guess;
-    std::get<0>(guess) = static_cast<t_Vector>(phi.adjoint() * target);
+    std::get<0>(guess) = static_cast<t_Vector>(phi.adjoint() * target) / nu;
     std::get<1>(guess) = target;
     return guess;
   }

--- a/cpp/sopt/primal_dual.h
+++ b/cpp/sopt/primal_dual.h
@@ -231,15 +231,15 @@ class PrimalDual {
 
   //! \brief Computes initial guess for x and the residual using the targets
   //! \details with y the vector of measurements
-  //! - x = Φ^T y * xi * tau
+  //! - x = Φ^T y / nu =  Φ^T y / (Φ_norm^2)
   //! - residuals = Φ x - y
   std::tuple<t_Vector, t_Vector> initial_guess() const {
-    return PrimalDual<SCALAR>::initial_guess(target(), Phi(), xi());
+    return PrimalDual<SCALAR>::initial_guess(target(), Phi(), nu());
   }
 
   //! \brief Computes initial guess for x and the residual using the targets
   //! \details with y the vector of measurements
-  //! - x = Φ^T y * xi * tau
+  //! - x = Φ^T y / nu =  Φ^T y / (Φ_norm^2)
   //! - residuals = Φ x - y
   //!
   //! This function simplifies creating overloads for operator() in PD wrappers.


### PR DESCRIPTION
In order to fix the primal dual issues in purify we need to correct this initial guess to include the normalisation factor for the linear operator. (nu = op_norm^2)

(This is the strategy that Tobias and I agreed made the most sense, as `nu` doesn't appear to be used for anything else in the PD algorithm and it means that the PD test can go back to using the same kind of linear operator setup as the other tests. We also checked that the definition of tau in the iterative update is correct, at least according to Luke's Purify / Primal Dual paper.)